### PR TITLE
validator: show independent operator quorum

### DIFF
--- a/src/app/AGENTS.md
+++ b/src/app/AGENTS.md
@@ -15,7 +15,8 @@ public network/payout transparency, and the hosted API reference.
 - `payouts/` - public worker payout transparency and live redacted jobs.
 - `network/` - public whole-network status: worker/model capacity, validator
   aggregates, charging mode, payout totals, incidents, and explicit
-  decentralization advisories.
+  decentralization advisories. Validator status keeps registered,
+  independently verified, and recently participating operator counts distinct.
 - `api-doc/` - Scalar API reference backed by `public/swagger.json`.
 - `api/` - server route handlers, owned by `api/AGENTS.md`.
 - Root layout/globals - metadata, providers, fonts, and global styling.

--- a/src/app/network/network-status-view.tsx
+++ b/src/app/network/network-status-view.tsx
@@ -42,6 +42,7 @@ interface ValidatorStatus {
   heartbeat_fresh: number;
   participating: number;
   verified_independent: number;
+  participating_independent?: number;
   independence_proven: boolean;
   quorum: Record<'pending' | 'accepted' | 'disputed' | 'finalized', number>;
   assignments_completed: number;
@@ -347,7 +348,11 @@ export default function NetworkStatusView() {
               <Metric
                 label='Verified independent'
                 value={data.validators?.verified_independent ?? 0}
-                detail='External review not yet proven'
+                detail={
+                  data.validators?.independence_proven
+                    ? `${data.validators.participating_independent ?? 0} participating in this window`
+                    : 'Reviewed operator quorum not yet proven'
+                }
                 icon={ShieldCheck}
               />
               <Metric

--- a/src/features/AGENTS.md
+++ b/src/features/AGENTS.md
@@ -28,7 +28,9 @@ in `src/app/dashboard/<area>/` stay thin and render the matching feature here.
   and finalization, and shows aggregate validator liveness without identities.
   Network health may show bounded agreement/dispute rates, worker/model
   coverage, and software-version cohorts. Keep registered, participating, and
-  independently verified operator counts visibly separate.
+  independently verified operator counts visibly separate. A probe group's
+  distinct-registration quorum and reviewed independent-operator quorum are
+  separate signals; never present the former as the latter.
   Shared 3-of-5 groups prove distinct registrations, not independent operators,
   and have no live routing, payout, reward, strike, or slash authority.
 - `settings/` — settings view + username-change section.

--- a/src/features/validators/components/validator-scorecards-view.tsx
+++ b/src/features/validators/components/validator-scorecards-view.tsx
@@ -79,6 +79,8 @@ interface ProbeGroupItem {
   quorum_outcome: string | null;
   assigned_validators: number;
   attested_validators: number;
+  independent_attested_operators?: number;
+  independent_quorum_reached?: boolean;
   threshold: number;
   target_validators: number;
   created: string | null;
@@ -130,8 +132,10 @@ interface AssignmentHealthResponse {
     }[];
     operator_independence: {
       verified: number;
+      participating?: number;
       proven: boolean;
       status: string;
+      minimum?: number;
     };
   };
   probe: Record<string, number>;
@@ -442,7 +446,8 @@ export default function ValidatorScorecardsView() {
           evidence hash. Shared 3-of-5 quorum is preview-only and has no
           economic authority. Staking and validator rewards are not live, and
           distinct registrations do not by themselves prove independent
-          operators.
+          operators. Verified operator counts require an expiring external
+          review and group common-control registrations together.
         </AlertDescription>
       </Alert>
 
@@ -680,8 +685,16 @@ export default function ValidatorScorecardsView() {
               ? (health?.network?.operator_independence.verified ?? 0)
               : '—'
           }
-          hint='External operator review pending'
-          icon={ShieldAlert}
+          hint={
+            health?.network?.operator_independence.proven
+              ? `${health.network.operator_independence.participating ?? 0} participating in this window`
+              : `Need ${health?.network?.operator_independence.minimum ?? 3} reviewed operators`
+          }
+          icon={
+            health?.network?.operator_independence.proven
+              ? ShieldCheck
+              : ShieldAlert
+          }
         />
       </div>
 
@@ -800,6 +813,11 @@ export default function ValidatorScorecardsView() {
                           threshold {item.threshold} · target{' '}
                           {item.target_validators}
                         </div>
+                        <div className='text-xs text-muted-foreground'>
+                          {item.independent_attested_operators ?? 0} independent
+                          {' / '}
+                          {item.threshold} required
+                        </div>
                       </TableCell>
                       <TableCell>
                         <div className='flex flex-wrap gap-1'>
@@ -809,6 +827,21 @@ export default function ValidatorScorecardsView() {
                               {item.quorum_outcome}
                             </Badge>
                           ) : null}
+                          <Badge
+                            variant={
+                              item.independent_quorum_reached
+                                ? 'default'
+                                : 'outline'
+                            }
+                          >
+                            {item.independent_quorum_reached
+                              ? 'independent quorum'
+                              : ['accepted', 'finalized'].includes(
+                                    item.quorum_status
+                                  )
+                                ? 'registration quorum only'
+                                : 'independence pending'}
+                          </Badge>
                         </div>
                       </TableCell>
                       <TableCell className='whitespace-nowrap text-right'>


### PR DESCRIPTION
## Summary
- display verified and recently participating independent operators separately
- show each probe group's reviewed independent-operator count and status
- keep ordinary distinct-registration quorum visibly separate from independent quorum
- consume only optional additive Core fields, so this can deploy before Core PR #31

## Verification
- `pnpm lint`
- `pnpm format:check`
- `pnpm build` (Next.js 16 production build, 41 routes)

## Safety
This is read-only aggregate UI. It exposes no validator ids, operator-group ids, wallets, review refs, prompts, outputs, nonces, or signatures. It adds no routing or economic authority.