### PR TITLE
validators: remove stale preview version label

### DIFF
--- a/src/features/validators/components/validator-scorecards-view.tsx
+++ b/src/features/validators/components/validator-scorecards-view.tsx
@@ -577,7 +577,7 @@ export default function ValidatorScorecardsView() {
                 production traffic.
               </p>
             </div>
-            <Badge variant='outline'>v0.1.0-preview.5</Badge>
+            <Badge variant='outline'>Unsigned preview</Badge>
           </div>
 
           <div className='grid gap-px overflow-hidden rounded-md border bg-border sm:grid-cols-2 xl:grid-cols-4'>


### PR DESCRIPTION
## Summary
- replace the duplicated stale `preview.5` badge with a durable `Unsigned preview` label
- keep the release-gated `/validate` page authoritative for the exact current validator version

## Verification
- `pnpm lint:strict`
- targeted Prettier check
- `pnpm build`
- history-inclusive gitleaks scan