### PR TITLE
feat(validators): explicit Console account pairing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,3 +34,5 @@ jobs:
         run: pnpm build
       - name: Test canonical account boundary
         run: pnpm test:auth-smoke
+      - name: Test validator account pairing boundary
+        run: pnpm test:validator-pairing

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,6 +104,9 @@ described as deployable until the build and Worker configuration land together.
   credit passthrough, anonymous rejection, and account-mismatch failure.
 - `Console CI / verify` runs the same checks on pushes and pull requests to
   `master` without production credentials.
+- `pnpm test:validator-pairing` exercises protected pairing routes against a
+  local mock Core after the build. Account association remains default off in
+  Core until the node client and supervised rollout are complete.
 - `gitleaks detect --source . --no-git --config .gitleaks.toml --redact`, then
   `gitleaks git . --log-opts=HEAD --config .gitleaks.toml --redact` from a full
   clone.
@@ -116,3 +119,5 @@ described as deployable until the build and Worker configuration land together.
 - [src/app/api/AGENTS.md](src/app/api/AGENTS.md) — server route handlers (the BFF / grid proxy).
 - [src/lib/AGENTS.md](src/lib/AGENTS.md) — auth and the grid v1 client.
 - [src/features/AGENTS.md](src/features/AGENTS.md) — per-route feature UI.
+- [src/features/validators/AGENTS.md](src/features/validators/AGENTS.md) - local
+  onboarding, optional private account pairing, and evidence views.

--- a/README.md
+++ b/README.md
@@ -46,3 +46,22 @@ payouts live in Grid core. The console does not require direct database access.
 Production currently deploys on Vercel. The checked-in Cloudflare/OpenNext import
 is incomplete and is not a supported deploy path until its package, Worker
 configuration, build, and runtime smoke tests are committed together.
+
+### Validator Account Pairing
+
+The released local operator app creates and keeps a dedicated validator signer
+and scoped key on the node. A personal wallet or Console-created key is not
+required to start a node.
+
+The new Console pairing flow is under review, not a public enablement. It pairs
+an existing node with an existing human account for private status visibility.
+The human approves in the Console, compares a code, then confirms separately in
+the local app. No node keys, payout rights, account merges, or economic authority
+are transferred. Core migration `0030`, the node client, and a supervised canary
+must land before enabling Core's default-off `VALIDATOR_PAIRING_ENABLED` flag.
+
+Run `pnpm build`, `pnpm test:auth-smoke`, and `pnpm test:validator-pairing` for
+local verification. `pnpm test:validator-pairing --ui` starts a test-only mock
+Core/sign-in fixture for browser QA; it uses no real accounts or production keys.
+See [validator DOX](src/features/validators/AGENTS.md) for contracts and rollout
+gates. Preview.12 does not yet contain local-app pairing controls.

--- a/next.config.js
+++ b/next.config.js
@@ -1,5 +1,17 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  async headers() {
+    return [
+      {
+        source: '/dashboard/connect-validator/:path*',
+        headers: [
+          { key: 'Referrer-Policy', value: 'no-referrer' },
+          { key: 'X-Frame-Options', value: 'DENY' },
+          { key: 'Content-Security-Policy', value: "frame-ancestors 'none'" }
+        ]
+      }
+    ];
+  },
   images: {
     remotePatterns: [
       {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "lint:fix": "eslint src --fix && pnpm format",
     "lint:strict": "eslint --max-warnings=0 src",
     "test:auth-smoke": "node scripts/auth-smoke.mjs",
+    "test:validator-pairing": "node scripts/validator-pairing-smoke.mjs",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "prepare": "husky"

--- a/scripts/validator-pairing-smoke.mjs
+++ b/scripts/validator-pairing-smoke.mjs
@@ -1,0 +1,490 @@
+// SPDX-FileCopyrightText: 2026 AI Power Grid
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { once } from 'node:events';
+import http from 'node:http';
+import { encode } from 'next-auth/jwt';
+
+const appOrigin = 'http://127.0.0.1:18894';
+const coreOrigin = 'http://127.0.0.1:18895';
+const authSecret = 'validator-pairing-local-test-secret-only';
+const cookieName = 'authjs.session-token';
+const accountId = '00000000-0000-0000-0000-000000000123';
+const pairingId = `vpa_${'a'.repeat(64)}`;
+const otherPairingId = `vpa_${'b'.repeat(64)}`;
+const validatorId = `val_${'1'.repeat(32)}`;
+const signer = `0x${'2'.repeat(40)}`;
+const path = `/api/validator-pairings/${pairingId}`;
+const nodePath = `/api/account/validators/${validatorId}/unlink`;
+const pagePath = `/dashboard/connect-validator/${pairingId}`;
+const ui = process.argv.includes('--ui');
+let state = 'pending';
+let replyMode = 'normal';
+let overrideStatus = 0;
+let expiresAt = Math.floor(Date.now() / 1000) + 600;
+let expectedToken = 'pairing-test-user-token';
+let exchangeAccount = accountId;
+let exchangeMode = 'normal';
+let nodeLinked = false;
+let followedRedirects = 0;
+const calls = [];
+const mockErrors = [];
+
+async function cookie(overrides = {}) {
+  const value = await encode({
+    token: {
+      sub: 'pairing-test-user',
+      provider_id: 'google_pairing-test-user',
+      name: 'Local validator test',
+      email: 'operator@example.test',
+      gridAccountId: accountId,
+      gridAccessToken: 'pairing-test-user-token',
+      gridAccessTokenExpiresAt: Date.now() + 30 * 60 * 1000,
+      ...overrides
+    },
+    secret: authSecret,
+    salt: cookieName,
+    maxAge: 3600
+  });
+  return `${cookieName}=${value}`;
+}
+
+function json(response, status, value) {
+  response.writeHead(status, { 'Content-Type': 'application/json' });
+  response.end(JSON.stringify(value));
+}
+
+function view() {
+  return {
+    pairing_id: replyMode === 'wrong-id' ? otherPairingId : pairingId,
+    validator_id: validatorId,
+    signing_wallet: signer,
+    status: state,
+    expires_at: expiresAt,
+    economic_effect: replyMode === 'economic' ? 'rewards' : 'none',
+    ...(state !== 'pending' ? { comparison_code: '12AB34CD' } : {}),
+    payload: { node_account_id: 'DO_NOT_RETURN_NODE_PAYLOAD' },
+    api_key: 'DO_NOT_RETURN_NODE_KEY'
+  };
+}
+
+function nodes() {
+  const node = {
+    validator_id: validatorId,
+    pairing_id: pairingId,
+    signing_wallet: signer,
+    status: 'active',
+    software_version: 'v0.1.0-preview.12',
+    last_heartbeat: new Date().toISOString(),
+    linked_at: new Date().toISOString(),
+    signature: 'DO_NOT_RETURN_SIGNATURE'
+  };
+  return {
+    nodes:
+      replyMode === 'too-many'
+        ? Array(101).fill(node)
+        : nodeLinked
+          ? [node]
+          : [],
+    economic_effect: 'none',
+    api_key: 'DO_NOT_RETURN_NODE_KEY'
+  };
+}
+
+const core = http.createServer(async (request, response) => {
+  try {
+    if (request.url === '/unexpected-redirect') {
+      followedRedirects += 1;
+      return json(response, 500, {});
+    }
+    // Optional isolated UI fixture. It exists only in this test process, never
+    // in the Console build, and issues a fake local session without real OAuth.
+    if (ui && request.url?.startsWith('/__test/')) {
+      if (request.url === '/__test/login') {
+        response.writeHead(302, {
+          'Set-Cookie': `${await cookie()}; HttpOnly; SameSite=Lax; Path=/`,
+          Location: `${appOrigin}${pagePath}`
+        });
+        return response.end();
+      }
+      if (request.method === 'POST') {
+        if (request.url === '/__test/confirm') {
+          state = 'linked';
+          nodeLinked = true;
+        }
+        if (request.url === '/__test/reset') {
+          state = 'pending';
+          nodeLinked = false;
+          overrideStatus = 0;
+          expiresAt = Math.floor(Date.now() / 1000) + 600;
+        }
+        if (request.url === '/__test/expire') {
+          expiresAt = Math.floor(Date.now() / 1000) - 1;
+        }
+        if (request.url === '/__test/reauth') overrideStatus = 403;
+        if (request.url === '/__test/off') overrideStatus = 503;
+        response.writeHead(302, { Location: '/__test/' });
+        return response.end();
+      }
+      response.writeHead(200, { 'Content-Type': 'text/html' });
+      return response.end(
+        `<h1>Local pairing test fixture</h1><p>No production accounts or keys.</p><a href="/__test/login">Open Console test session</a>${['confirm', 'reset', 'expire', 'reauth', 'off'].map((action) => `<form method="post" action="/__test/${action}"><button>${action}</button></form>`).join('')}`
+      );
+    }
+    const chunks = [];
+    for await (const chunk of request) chunks.push(chunk);
+    const body = chunks.length
+      ? JSON.parse(Buffer.concat(chunks).toString('utf8'))
+      : undefined;
+    if (request.url === '/v1/auth/service/exchange') {
+      assert.equal(request.headers.apikey, 'pairing-test-service-token');
+      assert.equal(body.subject, 'google_pairing-test-user');
+      if (exchangeMode === 'redirect') {
+        response.writeHead(302, {
+          Location: `${coreOrigin}/unexpected-redirect`
+        });
+        return response.end();
+      }
+      if (exchangeMode === 'timeout') {
+        const timer = setTimeout(() => json(response, 503, {}), 11_000);
+        response.on('close', () => clearTimeout(timer));
+        return;
+      }
+      return json(response, 200, {
+        access_token: 'refreshed-pairing-token',
+        account_id: exchangeAccount,
+        expires_in: 900
+      });
+    }
+    if (!request.url?.startsWith('/v1/account/validator'))
+      return json(response, 404, {});
+    calls.push({ path: request.url, method: request.method, body });
+    assert.equal(request.headers.apikey, expectedToken);
+    assert.equal(request.headers.authorization, undefined);
+    if (overrideStatus)
+      return json(response, overrideStatus, {
+        detail: 'DO_NOT_RETURN_ERROR_KEY'
+      });
+    if (replyMode === 'redirect') {
+      response.writeHead(302, {
+        Location: `${coreOrigin}/unexpected-redirect`
+      });
+      return response.end();
+    }
+    if (replyMode === 'timeout') {
+      const timer = setTimeout(() => json(response, 200, view()), 11_000);
+      response.on('close', () => clearTimeout(timer));
+      return;
+    }
+    if (replyMode === 'oversized')
+      return json(response, 200, { padding: 'x'.repeat(70_000) });
+    if (replyMode === 'malformed') return response.end('<html>Not JSON</html>');
+    if (request.url === '/v1/account/validators')
+      return json(response, 200, nodes());
+    if (request.url === `/v1/account/validators/${validatorId}/unlink`) {
+      assert.equal(request.method, 'POST');
+      assert.deepEqual(body, { pairing_id: pairingId });
+      nodeLinked = false;
+      return json(response, 200, {
+        status: 'unlinked',
+        validator_id: validatorId
+      });
+    }
+    if (request.url.endsWith('/approve')) {
+      assert.equal(request.method, 'POST');
+      assert.deepEqual(body, {});
+      state = 'approved';
+    }
+    if (expiresAt <= Math.floor(Date.now() / 1000))
+      return json(response, 409, {});
+    return json(response, 200, view());
+  } catch (error) {
+    mockErrors.push(error);
+    json(response, 500, { error: 'mock assertion failed' });
+  }
+});
+
+await new Promise((resolve, reject) => {
+  core.once('error', reject);
+  core.listen(18895, '127.0.0.1', resolve);
+});
+const app = spawn(
+  process.execPath,
+  [
+    'node_modules/next/dist/bin/next',
+    'start',
+    '--hostname',
+    '127.0.0.1',
+    '--port',
+    '18894'
+  ],
+  {
+    env: {
+      ...process.env,
+      AUTH_SECRET: authSecret,
+      NEXTAUTH_SECRET: authSecret,
+      AUTH_TRUST_HOST: 'true',
+      NEXTAUTH_URL: appOrigin,
+      GRID_API_BASE: coreOrigin,
+      GRID_SERVICE_API_KEY: 'pairing-test-service-token'
+    },
+    stdio: ['ignore', 'pipe', 'pipe']
+  }
+);
+let appOutput = '';
+app.stdout.on('data', (chunk) => {
+  appOutput = (appOutput + chunk).slice(-16_000);
+});
+app.stderr.on('data', (chunk) => {
+  appOutput = (appOutput + chunk).slice(-16_000);
+});
+let currentCookie = await cookie();
+
+function request(route, init = {}) {
+  return fetch(`${appOrigin}${route}`, {
+    ...init,
+    headers: { cookie: currentCookie, ...init.headers },
+    signal: AbortSignal.timeout(15_000),
+    redirect: 'manual'
+  });
+}
+function post(route, body = {}, headers = {}) {
+  return request(route, {
+    method: 'POST',
+    headers: {
+      Origin: appOrigin,
+      'Content-Type': 'application/json',
+      ...headers
+    },
+    body: typeof body === 'string' ? body : JSON.stringify(body)
+  });
+}
+async function status(response, expected) {
+  assert.equal(response.status, expected);
+  assert.equal(response.headers.get('cache-control'), 'no-store');
+  assert.equal(response.headers.get('referrer-policy'), 'no-referrer');
+  const body = await response.text();
+  assert.ok(
+    !/DO_NOT_RETURN|pairing-test-user-token|pairing-test-service-token/.test(
+      body
+    )
+  );
+  return JSON.parse(body);
+}
+
+try {
+  let ready = false;
+  for (let attempt = 0; attempt < 100; attempt++) {
+    try {
+      if ((await fetch(`${appOrigin}/api/account/validators`)).status === 401) {
+        ready = true;
+        break;
+      }
+    } catch {
+      /* Bounded startup retry; never a production request. */
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  assert.ok(ready, `Console failed to start: ${appOutput}`);
+  if (ui) {
+    console.log(`Local pairing fixture: ${coreOrigin}/__test/`);
+    console.log(`Console: ${appOrigin}${pagePath}`);
+    await new Promise((resolve) => {
+      const timer = setTimeout(resolve, 30 * 60 * 1000);
+      process.once('SIGINT', () => {
+        clearTimeout(timer);
+        resolve();
+      });
+      process.once('SIGTERM', () => {
+        clearTimeout(timer);
+        resolve();
+      });
+    });
+  } else {
+    await status(
+      await request(path, {
+        headers: {
+          cookie: '',
+          apikey: 'forged',
+          authorization: 'Bearer forged'
+        }
+      }),
+      401
+    );
+    await status(await post(`${path}/approve`, {}, { cookie: '' }), 401);
+    assert.equal(calls.length, 0);
+
+    for (const origin of [
+      '',
+      'null',
+      'https://evil.example',
+      'http://localhost:18894'
+    ]) {
+      await status(
+        await post(
+          `${path}/approve`,
+          {},
+          { Origin: origin, 'X-Forwarded-Host': 'evil.example' }
+        ),
+        403
+      );
+    }
+    await status(
+      await post(`${path}/approve`, {}, { 'Sec-Fetch-Site': 'cross-site' }),
+      403
+    );
+    await status(
+      await post(`${path}/approve`, {}, { 'Content-Type': 'text/plain' }),
+      415
+    );
+    for (const body of [
+      '{',
+      JSON.stringify({ account_id: accountId }),
+      JSON.stringify({ data: 'x'.repeat(300) })
+    ])
+      await status(await post(`${path}/approve`, body), 400);
+    await status(await request('/api/validator-pairings/invalid'), 404);
+    await status(
+      await post('/api/account/validators/invalid/unlink', {
+        pairing_id: pairingId
+      }),
+      404
+    );
+    await status(
+      await post(nodePath, {
+        pairing_id: pairingId,
+        operator_account_id: accountId
+      }),
+      400
+    );
+    await status(
+      await request(`${path}/approve`, {
+        method: 'POST',
+        headers: { Origin: appOrigin, 'Content-Type': 'application/json' },
+        duplex: 'half',
+        body: new ReadableStream({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode('{"extra":"'));
+            controller.enqueue(
+              new TextEncoder().encode(`${'x'.repeat(400)}"}`)
+            );
+            controller.close();
+          }
+        })
+      }),
+      400
+    );
+    assert.equal(calls.length, 0, 'rejected requests must never reach Core');
+
+    const pending = await status(
+      await request(path, {
+        headers: { apikey: 'ignored', authorization: 'Bearer ignored' }
+      }),
+      200
+    );
+    assert.equal(pending.status, 'pending');
+    assert.equal(pending.payload, undefined);
+    assert.equal(calls.at(-1).method, 'GET');
+    assert.equal(state, 'pending', 'reads do not approve');
+    assert.equal((await request(`${path}/approve`)).status, 405);
+    const approved = await status(await post(`${path}/approve`), 200);
+    assert.equal(approved.status, 'approved');
+    assert.equal(approved.comparison_code, '12AB34CD');
+    assert.equal(nodeLinked, false, 'Console approval cannot confirm the node');
+    await status(await post(`${path}/approve`), 200);
+
+    for (const code of [401, 403, 404, 409, 429, 503]) {
+      overrideStatus = code;
+      await status(await request(path), code);
+      await status(await post(`${path}/approve`), code);
+    }
+    overrideStatus = 500;
+    await status(await request(path), 502);
+    overrideStatus = 0;
+    for (const mode of [
+      'wrong-id',
+      'economic',
+      'redirect',
+      'oversized',
+      'malformed',
+      'timeout'
+    ]) {
+      replyMode = mode;
+      await status(await request(path), 502);
+    }
+    replyMode = 'normal';
+
+    state = 'linked';
+    nodeLinked = true;
+    const linked = await status(await request('/api/account/validators'), 200);
+    assert.equal(linked.nodes.length, 1);
+    assert.equal(linked.nodes[0].signature, undefined);
+    replyMode = 'too-many';
+    await status(await request('/api/account/validators'), 502);
+    replyMode = 'normal';
+    overrideStatus = 403;
+    await status(await post(nodePath, { pairing_id: pairingId }), 403);
+    assert.equal(nodeLinked, true);
+    overrideStatus = 0;
+    await status(await post(nodePath, { pairing_id: pairingId }), 200);
+    assert.equal(nodeLinked, false);
+    await status(await post(nodePath, { pairing_id: pairingId }), 200);
+
+    currentCookie = await cookie({ gridAccessTokenExpiresAt: Date.now() - 1 });
+    expectedToken = 'refreshed-pairing-token';
+    const beforeRefreshFailures = calls.length;
+    exchangeMode = 'redirect';
+    await status(await request('/api/account/validators'), 401);
+    exchangeMode = 'timeout';
+    await status(await request('/api/account/validators'), 502);
+    assert.equal(calls.length, beforeRefreshFailures);
+    exchangeMode = 'normal';
+    await status(await request('/api/account/validators'), 200);
+    overrideStatus = 403;
+    await status(await post(`${path}/approve`), 403);
+    overrideStatus = 0;
+    exchangeAccount = '00000000-0000-0000-0000-000000000999';
+    const beforeMismatch = calls.length;
+    await status(await request('/api/account/validators'), 401);
+    assert.equal(
+      calls.length,
+      beforeMismatch,
+      'canonical account mismatch fails closed'
+    );
+    currentCookie = await cookie();
+    expectedToken = 'pairing-test-user-token';
+
+    const page = await request(pagePath);
+    assert.equal(page.status, 200);
+    assert.equal(page.headers.get('referrer-policy'), 'no-referrer');
+    assert.equal(page.headers.get('x-frame-options'), 'DENY');
+    assert.equal(
+      page.headers.get('content-security-policy'),
+      "frame-ancestors 'none'"
+    );
+    assert.ok((await page.text()).includes('Link validator'));
+    const anonymousPage = await request(pagePath, { headers: { cookie: '' } });
+    assert.ok([302, 307].includes(anonymousPage.status));
+    assert.equal(mockErrors.length, 0, String(mockErrors[0] ?? ''));
+    assert.equal(
+      followedRedirects,
+      0,
+      'neither user nor service credentials may follow a redirect'
+    );
+    console.log(
+      'Validator pairing auth, origin, body, privacy, lifecycle proxy, refresh, timeout and page gates passed'
+    );
+  }
+} finally {
+  if (app.exitCode === null && app.signalCode === null) {
+    const exited = once(app, 'exit');
+    app.kill('SIGTERM');
+    const killTimer = setTimeout(() => app.kill('SIGKILL'), 5000);
+    await exited;
+    clearTimeout(killTimer);
+  }
+  core.closeAllConnections();
+  await new Promise((resolve) => core.close(resolve));
+}

--- a/src/app/AGENTS.md
+++ b/src/app/AGENTS.md
@@ -10,6 +10,9 @@ public network/payout transparency, and the hosted API reference.
 - `(auth)/(signin)/` - Google, GitHub, and wallet sign-in entry page.
 - `dashboard/connect-worker/[enrollmentId]/` - protected, short-lived worker
   delegation review and payout-wallet approval screen.
+- `dashboard/connect-validator/[pairingId]/` - protected, short-lived validator
+  account-visibility approval. No-referrer metadata/HTTP header and frame denial
+  protect the request URL and consent screen. Node confirmation remains local.
 - `dashboard/` - protected account pages: overview, API keys, credits/funding,
   usage, rewards, settings, validators, and workers.
 - `payouts/` - public worker payout transparency and live redacted jobs.

--- a/src/app/api/AGENTS.md
+++ b/src/app/api/AGENTS.md
@@ -24,6 +24,11 @@ browser JavaScript.
 - `worker-enrollments/[enrollmentId]/` — public safe-intent read plus
   session-gated prepare/approve proxies. Validate IDs, addresses, and signatures;
   never proxy manager poll secrets or candidate worker credentials to the browser.
+- `validator-pairings/[pairingId]/` and `approve/` - authenticated inspect and
+  approval of an existing node's optional account-visibility request. Owned by
+  `validator-pairings/AGENTS.md`, including shared transport rules.
+- `account/validators/` and `[validatorId]/unlink/` - private associated-node
+  listing and exact-pairing removal; use that same validator-pairing transport.
 - `account/jobs/` — operator trust view (my workers' jobs + den + proof) via
   `/v1/account/jobs`.
 - `account/payout-preference/` — set payout asset / AIPG slice via the
@@ -63,8 +68,9 @@ browser JavaScript.
 
 ## Verification
 
-—
+- `pnpm test:auth-smoke` and `pnpm test:validator-pairing` after `pnpm build`.
 
 ## Child DOX Index
 
-- None — leaf.
+- [validator-pairings/AGENTS.md](validator-pairings/AGENTS.md) - bounded private
+  account-pairing proxies and cross-origin protection.

--- a/src/app/api/account/validators/[validatorId]/unlink/route.ts
+++ b/src/app/api/account/validators/[validatorId]/unlink/route.ts
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: 2026 AI Power Grid
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { NextRequest } from 'next/server';
+import { z } from 'zod';
+import {
+  callPairing,
+  pairingError,
+  pairingForm
+} from '@/app/api/validator-pairings/_shared';
+import {
+  unlinkValidatorSchema,
+  validatorIdSchema
+} from '@/lib/validator-pairing';
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ validatorId: string }> }
+) {
+  const { validatorId } = await params;
+  if (!validatorIdSchema.safeParse(validatorId).success)
+    return pairingError(404);
+  const form = await pairingForm(req, unlinkValidatorSchema);
+  if ('error' in form) return form.error;
+  return callPairing(
+    req,
+    `/v1/account/validators/${validatorId}/unlink`,
+    z.object({ status: z.literal('unlinked') }),
+    form.data
+  );
+}

--- a/src/app/api/account/validators/route.ts
+++ b/src/app/api/account/validators/route.ts
@@ -1,0 +1,10 @@
+// SPDX-FileCopyrightText: 2026 AI Power Grid
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { NextRequest } from 'next/server';
+import { callPairing } from '@/app/api/validator-pairings/_shared';
+import { linkedValidatorsSchema } from '@/lib/validator-pairing';
+
+export async function GET(req: NextRequest) {
+  return callPairing(req, '/v1/account/validators', linkedValidatorsSchema);
+}

--- a/src/app/api/validator-pairings/AGENTS.md
+++ b/src/app/api/validator-pairings/AGENTS.md
@@ -1,0 +1,48 @@
+# validator-pairings - private Console proxy
+
+## Ownership
+
+`_shared.ts` supplies bounded transport, no-store responses, and same-origin JSON
+mutation checks for this subtree and `../account/validators/`.
+
+| Browser route                               | Core target                           | Permission                      |
+| ------------------------------------------- | ------------------------------------- | ------------------------------- |
+| GET `/api/validator-pairings/{id}`          | `/v1/account/validator-pairings/{id}` | Fresh account.manage user proof |
+| POST `/api/validator-pairings/{id}/approve` | Same Core path plus `/approve`        | Fresh account.manage user proof |
+| GET `/api/account/validators`               | `/v1/account/validators`              | account.read user token         |
+| POST `/api/account/validators/{id}/unlink`  | Same Core path plus `/unlink`         | Fresh account.manage user proof |
+
+## Boundaries
+
+- Derive the Core user token only from the encrypted Auth.js session through
+  `getSessionToken` / `resolveGridKey`. Ignore inbound API keys and Bearer tokens.
+  Canonical-account mismatch on token refresh fails closed.
+- Core enforces user-token kind, Google/SIWE freshness, ownership and lifecycle.
+  A refresh does not acquire account-manage permission. Preserve 401/403 for
+  explicit reauthentication; never fall back to the Console service key.
+- Validate `vpa_` plus 64 lowercase hex and `val_` plus 32 lowercase hex before
+  constructing fixed upstream paths. Never accept a destination URL/account ID.
+- Writes require exact Origin against request protocol/Host, same-origin
+  Fetch Metadata when present, and JSON. Do not trust X-Forwarded-Host or allow
+  same-site subdomains. The edge must keep its normal Host routing validation.
+- Approve body is strictly `{}`. Unlink body is strictly `{pairing_id}`. Read
+  at most 256 bytes, including chunked bodies. No browser-supplied signature.
+- Core transport is no-store, ten-second timeout including token refresh,
+  no redirects, max 64 KiB metadata JSON.
+  Validate and allowlist response fields; strip node signing payload, accounts,
+  signatures and any future credentials. Require `economic_effect: none`.
+- Sanitize errors rather than relaying driver/HTML/upstream credential data.
+  Preserve 401/403/404/409/429/503; other upstream failures become 502.
+- All proxy responses use no-store and no-referrer. There is no public pairing
+  inspection endpoint, local database, cache, or browser credential persistence.
+
+## Verification
+
+`pnpm build` then `pnpm test:validator-pairing`. The production-server smoke
+uses a local mock Core to check auth, origin/content/body gates, field filtering,
+canonical refresh, explicit mutations, bounded failures, and protected-page
+headers. Core's real Postgres/signature tests remain a separate required gate.
+
+## Child DOX Index
+
+- None - leaf.

--- a/src/app/api/validator-pairings/[pairingId]/approve/route.ts
+++ b/src/app/api/validator-pairings/[pairingId]/approve/route.ts
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: 2026 AI Power Grid
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { NextRequest } from 'next/server';
+import { z } from 'zod';
+import { pairingIdSchema, pairingViewSchema } from '@/lib/validator-pairing';
+import { callPairing, pairingError, pairingForm } from '../../_shared';
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ pairingId: string }> }
+) {
+  const { pairingId } = await params;
+  if (!pairingIdSchema.safeParse(pairingId).success) return pairingError(404);
+  const form = await pairingForm(req, z.object({}).strict());
+  if ('error' in form) return form.error;
+  return callPairing(
+    req,
+    `/v1/account/validator-pairings/${pairingId}/approve`,
+    pairingViewSchema.refine((view) => view.pairing_id === pairingId),
+    form.data
+  );
+}

--- a/src/app/api/validator-pairings/[pairingId]/route.ts
+++ b/src/app/api/validator-pairings/[pairingId]/route.ts
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: 2026 AI Power Grid
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { NextRequest } from 'next/server';
+import { pairingIdSchema, pairingViewSchema } from '@/lib/validator-pairing';
+import { callPairing, pairingError } from '../_shared';
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ pairingId: string }> }
+) {
+  const { pairingId } = await params;
+  if (!pairingIdSchema.safeParse(pairingId).success) return pairingError(404);
+  return callPairing(
+    req,
+    `/v1/account/validator-pairings/${pairingId}`,
+    pairingViewSchema.refine((view) => view.pairing_id === pairingId)
+  );
+}

--- a/src/app/api/validator-pairings/_shared.ts
+++ b/src/app/api/validator-pairings/_shared.ts
@@ -1,0 +1,105 @@
+// SPDX-FileCopyrightText: 2026 AI Power Grid
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { getSessionToken, resolveGridKey } from '@/lib/grid-account';
+import { GRID_API_BASE } from '@/lib/grid-api';
+import { pairingErrorMessage } from '@/lib/validator-pairing';
+
+const privateHeaders = {
+  'Cache-Control': 'no-store',
+  'Referrer-Policy': 'no-referrer',
+  'X-Content-Type-Options': 'nosniff'
+};
+
+export function pairingError(status: number) {
+  return NextResponse.json(
+    { error: pairingErrorMessage(status) },
+    { status, headers: privateHeaders }
+  );
+}
+
+async function boundedJson(
+  stream: ReadableStream<Uint8Array> | null,
+  limit: number
+): Promise<unknown> {
+  if (!stream) throw new Error('Missing JSON body');
+  const reader = stream.getReader();
+  const chunks: Uint8Array[] = [];
+  let size = 0;
+  try {
+    for (;;) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      size += value.byteLength;
+      if (size > limit) throw new Error('JSON body too large');
+      chunks.push(value);
+    }
+    return JSON.parse(Buffer.concat(chunks).toString('utf8'));
+  } finally {
+    await reader.cancel();
+  }
+}
+
+export async function pairingForm<T>(req: NextRequest, schema: z.ZodType<T>) {
+  // Cookie-authenticated writes require a same-origin JSON fetch, not a form
+  // submission or a caller-controlled forwarding header.
+  const site = req.headers.get('sec-fetch-site');
+  // NextURL normalizes loopback IPs to localhost. The actual Host remains the
+  // browser's authority; do not weaken this to a same-site/forwarded-host check.
+  const origin = `${req.nextUrl.protocol}//${req.headers.get('host')}`;
+  if (
+    req.headers.get('origin') !== origin ||
+    (site && site !== 'same-origin')
+  ) {
+    return { error: pairingError(403) } as const;
+  }
+  if (
+    req.headers.get('content-type')?.split(';')[0].trim() !== 'application/json'
+  ) {
+    return { error: pairingError(415) } as const;
+  }
+  try {
+    const parsed = schema.safeParse(await boundedJson(req.body, 256));
+    if (!parsed.success) return { error: pairingError(400) } as const;
+    return { data: parsed.data } as const;
+  } catch {
+    return { error: pairingError(400) } as const;
+  }
+}
+
+export async function callPairing<T>(
+  req: NextRequest,
+  path: string,
+  schema: z.ZodType<T>,
+  body?: unknown
+) {
+  try {
+    const signal = AbortSignal.timeout(10_000);
+    const key = await resolveGridKey(await getSessionToken(req), signal);
+    if (signal.aborted) return pairingError(502);
+    if (!key) return pairingError(401);
+    const response = await fetch(`${GRID_API_BASE}${path}`, {
+      method: body === undefined ? 'GET' : 'POST',
+      headers: { apikey: key, 'Content-Type': 'application/json' },
+      body: body === undefined ? undefined : JSON.stringify(body),
+      cache: 'no-store',
+      redirect: 'error',
+      signal
+    });
+    if (!response.ok) {
+      await response.body?.cancel();
+      const status = [401, 403, 404, 409, 429, 503].includes(response.status)
+        ? response.status
+        : 502;
+      return pairingError(status);
+    }
+    const parsed = schema.safeParse(await boundedJson(response.body, 65_536));
+    if (!parsed.success) return pairingError(502);
+    return NextResponse.json(parsed.data, { headers: privateHeaders });
+  } catch {
+    // Never send upstream error bodies, tokens, or signing payloads to the UI.
+    return pairingError(502);
+  }
+}

--- a/src/app/dashboard/connect-validator/[pairingId]/page.tsx
+++ b/src/app/dashboard/connect-validator/[pairingId]/page.tsx
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: 2026 AI Power Grid
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import type { Metadata } from 'next';
+import { notFound } from 'next/navigation';
+import PageContainer from '@/components/layout/page-container';
+import ValidatorPairing from '@/features/validators/components/validator-pairing';
+import { pairingIdSchema } from '@/lib/validator-pairing';
+
+export const metadata: Metadata = {
+  title: 'Link Validator',
+  referrer: 'no-referrer',
+  robots: { index: false, follow: false }
+};
+
+export default async function Page({
+  params
+}: {
+  params: Promise<{ pairingId: string }>;
+}) {
+  const { pairingId } = await params;
+  if (!pairingIdSchema.safeParse(pairingId).success) notFound();
+  return (
+    <PageContainer>
+      <ValidatorPairing pairingId={pairingId} />
+    </PageContainer>
+  );
+}

--- a/src/features/AGENTS.md
+++ b/src/features/AGENTS.md
@@ -18,13 +18,13 @@ in `src/app/dashboard/<area>/` stay thin and render the matching feature here.
 - `workers/` — worker list plus device-enrollment approval. The browser signs
   only Core's exact delegation message and locally confirms the recovered
   signer before approval. `profile/` — profile view + create form (`utils/form-schema.ts`).
-- `validators/` — validator onboarding plus aggregate evidence scorecards and
-  assignment health. Onboarding first installs the exact preview and prepares
-  the signing identity locally, then links only its public address, issues a
-  one-time validator-purpose key with the exact validator scopes, and completes
-  local initialization. The Console never generates, receives, or stores the
-  validator private key. The public release gate exposes downloads only after
-  the matching Core migration and verified preview release are live.
+- `validators/` — local-app onboarding, optional private account association,
+  aggregate evidence scorecards, and assignment health. Owned in its own
+  AGENTS.md. The released app creates a dedicated node identity and scoped key
+  locally; no manual Console key or personal wallet is required. The Console
+  never generates, receives, or stores the validator private key.
+  Account pairing is a separate, default-off Core feature pending coordinated
+  node-client release and canary; it grants visibility, not node control.
   Preview and assignment-bound evidence must be visually distinct. The page
   separates probe completion, accepted signed evidence, worker pass, quorum,
   and finalization, and shows aggregate validator liveness without identities.
@@ -54,9 +54,10 @@ in `src/app/dashboard/<area>/` stay thin and render the matching feature here.
   URL directly). Server components may use `gridFetch` from `src/lib/grid-api.ts`.
 - Worker enrollment must verify Core's canonical delegation fields and message
   locally before opening the wallet signature prompt.
-- Validator key plaintext is displayed once and must never be stored in browser
-  persistence or logged. Do not offer onboarding until the canonical account has
-  a linked wallet; the node's signing wallet must match it during registration.
+- Validator account pairing requires explicit Console approval followed by an
+  explicit confirmation on the node. Never auto-approve on login or poll,
+  request a node private key, or treat account association as ownership,
+  recovery, payout delegation, or operator independence.
 - Forms use React Hook Form + Zod schemas (e.g. `profile/utils/form-schema.ts`).
 - Funding may use any wallet that Core has verified on the canonical account.
   The funding selector renders only assets Core marks enabled; disabled future
@@ -79,4 +80,5 @@ in `src/app/dashboard/<area>/` stay thin and render the matching feature here.
 
 ## Child DOX Index
 
-- None — leaf.
+- [validators/AGENTS.md](validators/AGENTS.md) - onboarding, private pairing,
+  and evidence-view contracts.

--- a/src/features/validators/AGENTS.md
+++ b/src/features/validators/AGENTS.md
@@ -1,0 +1,69 @@
+# validators - onboarding, account visibility and evidence
+
+## Purpose
+
+Help operators install the released local app, optionally associate an existing
+node with their human account, and inspect aggregate evidence without inventing
+validator economic authority or model-quality guarantees.
+
+## Ownership
+
+- `components/validator-onboarding.tsx` - released local-app setup guidance;
+  do not restore manual private-key/API-key entry as the default.
+- `components/validator-pairing.tsx` - protected, expiring approval page.
+- `components/pairing-step-up.tsx` - existing Google/SIWE sign-in buttons with
+  a same-origin return path. Login never executes a pending action.
+- `components/linked-validators.tsx` - authenticated current associations and
+  exact-association removal with confirmation.
+- `components/validator-scorecards-view.tsx` - existing aggregate health and
+  evidence dimensions; private node links do not affect public aggregates.
+- Shared bounded display schemas: `src/lib/validator-pairing.ts`.
+- `src/hooks/use-breadcrumbs.tsx` uses a short consent-page label rather than
+  displaying the opaque pairing ID in navigation.
+- Server proxies: `src/app/api/validator-pairings/` and
+  `src/app/api/account/validators/`.
+
+## Pairing Contract
+
+The Core implementation is default off. This Console work is not a production
+enablement, and preview.12 does not include local-app pairing controls. Coordinate
+Core migration `0030`, both clients, a reviewed node release, and a supervised
+canary before enabling `VALIDATOR_PAIRING_ENABLED`. Running an unpaired node
+continues to work. Existing nodes retain their dedicated account, signer, and key.
+
+1. A node starts a ten-minute opaque request in its local app.
+2. `/dashboard/connect-validator/{pairing_id}` loads authenticated metadata.
+   Core requires a recent Google/SIWE proof; GitHub alone cannot approve.
+3. The human explicitly approves the displayed node for the current account.
+4. The page displays Core's comparison code and polls at five-second intervals.
+   The operator must compare it and explicitly confirm in the local app.
+5. Only Core's `linked` status is success. Expiry/errors offer the linked-node
+   list and explicit retry; no auto-approval, signing, or account merging.
+6. Removal posts the displayed exact `pairing_id` after confirmation. A changed
+   association is not silently removed. Reauthentication requires another click.
+
+The human account gains private visibility only: node ID, signer, registration
+status, version, and heartbeat. Registration `active` is not an online-health
+claim. Never expose the node-only signing payload, key, private account ID,
+signature, or operator association in public health/evidence views.
+
+The association does not grant validator control, recovery, stake, payout
+rights, quorum seats, or independent-operator status. Removing it does not stop
+the node or change keys, balances, payout wallets, or evidence history.
+
+## Verification
+
+- `pnpm lint:strict`, `pnpm format:check`, `pnpm build`.
+- `pnpm test:auth-smoke` and `pnpm test:validator-pairing` after the build.
+- `pnpm test:validator-pairing --ui` starts an isolated mock Core and Console
+  with a fake local sign-in fixture. The fixture is test-process-only and never
+  part of deployed App Router code. Stop it after browser QA.
+- Verify pending -> approved -> separately confirmed -> linked; expired,
+  unavailable, fresh-login, remove/cancel states; reload recovery; 320px and
+  desktop layouts. Mock confirmation is not proof of real node signing.
+- Real Windows/Linux pairing, end-to-end signature verification, and the
+  production canary remain coordinated rollout gates, not Console smoke claims.
+
+## Child DOX Index
+
+- None - leaf.

--- a/src/features/validators/components/linked-validators.tsx
+++ b/src/features/validators/components/linked-validators.tsx
@@ -1,0 +1,211 @@
+// SPDX-FileCopyrightText: 2026 AI Power Grid
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+'use client';
+
+import { useEffect, useState } from 'react';
+import { z } from 'zod';
+import { Link2Off, RefreshCw } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogCancel,
+  AlertDialogAction
+} from '@/components/ui/alert-dialog';
+import {
+  LinkedValidator,
+  PairingRequestError,
+  linkedValidatorsSchema,
+  readPairingResponse
+} from '@/lib/validator-pairing';
+import { PairingStepUp } from './pairing-step-up';
+
+export default function LinkedValidators() {
+  const [nodes, setNodes] = useState<LinkedValidator[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<PairingRequestError | null>(null);
+  const [revision, setRevision] = useState(0);
+  const [selected, setSelected] = useState<LinkedValidator | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    setLoading(true);
+    async function load() {
+      try {
+        const result = await readPairingResponse(
+          await fetch('/api/account/validators', {
+            cache: 'no-store',
+            signal: controller.signal
+          }),
+          linkedValidatorsSchema
+        );
+        if (controller.signal.aborted) return;
+        setNodes(result.nodes);
+        setError(null);
+      } catch (err) {
+        if (controller.signal.aborted) return;
+        setNodes([]);
+        setError(
+          err instanceof PairingRequestError
+            ? err
+            : new PairingRequestError(502)
+        );
+      } finally {
+        if (!controller.signal.aborted) setLoading(false);
+      }
+    }
+    void load();
+    return () => controller.abort();
+  }, [revision]);
+
+  async function unlink() {
+    if (!selected || busy) return;
+    setBusy(true);
+    try {
+      await readPairingResponse(
+        await fetch(`/api/account/validators/${selected.validator_id}/unlink`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ pairing_id: selected.pairing_id }),
+          cache: 'no-store'
+        }),
+        z.object({ status: z.literal('unlinked') })
+      );
+      setNodes((items) =>
+        items.filter((item) => item.pairing_id !== selected.pairing_id)
+      );
+      setError(null);
+      setRevision((value) => value + 1);
+    } catch (err) {
+      setError(
+        err instanceof PairingRequestError ? err : new PairingRequestError(502)
+      );
+    } finally {
+      setBusy(false);
+      setSelected(null);
+    }
+  }
+
+  return (
+    <section
+      className='min-w-0 space-y-4 border-y py-6'
+      aria-labelledby='linked-validators-heading'
+    >
+      <div className='flex items-center justify-between gap-3'>
+        <h2 id='linked-validators-heading' className='font-semibold'>
+          Your linked validators
+        </h2>
+        <Button
+          variant='outline'
+          size='icon'
+          title='Refresh linked validators'
+          aria-label='Refresh linked validators'
+          disabled={loading || busy}
+          onClick={() => setRevision((value) => value + 1)}
+        >
+          <RefreshCw className='h-4 w-4' />
+        </Button>
+      </div>
+      {loading && (
+        <p role='status' className='text-sm text-muted-foreground'>
+          Loading linked nodes...
+        </p>
+      )}
+      {error && (
+        <div className='space-y-4'>
+          <p role='alert' className='text-sm text-muted-foreground'>
+            {error.message}
+          </p>
+          {[401, 403].includes(error.status) && (
+            <PairingStepUp returnTo='/dashboard/validators' />
+          )}
+        </div>
+      )}
+      {!loading && !error && nodes.length === 0 && (
+        <p className='text-sm text-muted-foreground'>
+          No nodes linked to this account. Running a validator does not require
+          an account link.
+        </p>
+      )}
+      <ul className='divide-y'>
+        {nodes.map((node) => (
+          <li
+            key={node.validator_id}
+            className='flex min-w-0 flex-col gap-4 py-4 sm:flex-row sm:items-start'
+          >
+            <dl className='grid min-w-0 flex-1 gap-x-4 gap-y-2 text-sm sm:grid-cols-[7rem_minmax(0,1fr)]'>
+              <dt className='text-muted-foreground'>Validator</dt>
+              <dd className='break-all font-mono'>{node.validator_id}</dd>
+              <dt className='text-muted-foreground'>Signer</dt>
+              <dd className='break-all font-mono'>{node.signing_wallet}</dd>
+              <dt className='text-muted-foreground'>Registration</dt>
+              <dd className='break-words capitalize'>{node.status}</dd>
+              <dt className='text-muted-foreground'>Last heartbeat</dt>
+              <dd>
+                {node.last_heartbeat ? (
+                  <time dateTime={node.last_heartbeat}>
+                    {new Date(node.last_heartbeat).toLocaleString()}
+                  </time>
+                ) : (
+                  'Not received'
+                )}
+              </dd>
+              <dt className='text-muted-foreground'>Version</dt>
+              <dd className='break-all'>
+                {node.software_version ?? 'Not reported'}
+              </dd>
+            </dl>
+            <Button
+              className='self-start'
+              variant='outline'
+              size='sm'
+              disabled={busy}
+              onClick={() => setSelected(node)}
+            >
+              <Link2Off className='mr-2 h-4 w-4' />
+              Remove link
+            </Button>
+          </li>
+        ))}
+      </ul>
+      <AlertDialog
+        open={!!selected}
+        onOpenChange={(open) => {
+          if (!open && !busy) setSelected(null);
+        }}
+      >
+        <AlertDialogContent className='w-[calc(100%-2rem)] max-w-lg rounded-lg'>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Remove this account link?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This removes visibility in your account. The validator keeps
+              running with the same keys, evidence history, and payout settings.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <p className='min-w-0 break-all font-mono text-sm'>
+            {selected?.validator_id}
+          </p>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={busy}>Keep link</AlertDialogCancel>
+            <AlertDialogAction
+              disabled={busy}
+              onClick={(event) => {
+                event.preventDefault();
+                void unlink();
+              }}
+            >
+              <Link2Off className='mr-2 h-4 w-4' />
+              {busy ? 'Removing...' : 'Remove link'}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </section>
+  );
+}

--- a/src/features/validators/components/pairing-step-up.tsx
+++ b/src/features/validators/components/pairing-step-up.tsx
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: 2026 AI Power Grid
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+'use client';
+
+import { Suspense } from 'react';
+import GoogleSignInButton from '@/features/auth/components/google-auth-button';
+import Web3AuthButton from '@/features/auth/components/web3-auth-button';
+
+export function PairingStepUp({ returnTo }: { returnTo: string }) {
+  return (
+    <div className='max-w-sm space-y-3'>
+      <p className='text-sm text-muted-foreground'>
+        Use the Google account or wallet already linked to your AIPG account.
+        Signing in does not approve or remove a node.
+      </p>
+      <Suspense
+        fallback={<p className='text-sm'>Loading sign-in options...</p>}
+      >
+        <div className='grid gap-3 [&_button]:mt-0'>
+          <GoogleSignInButton returnTo={returnTo} />
+          <Web3AuthButton returnTo={returnTo} />
+        </div>
+      </Suspense>
+    </div>
+  );
+}

--- a/src/features/validators/components/validator-onboarding.tsx
+++ b/src/features/validators/components/validator-onboarding.tsx
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText: 2026 AI Power Grid
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { Download, ExternalLink } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+
+export default function ValidatorOnboarding() {
+  return (
+    <section
+      className='space-y-4 py-2'
+      aria-labelledby='validator-onboarding-heading'
+    >
+      <div className='flex flex-wrap items-center gap-3'>
+        <h2 id='validator-onboarding-heading' className='font-semibold'>
+          Run a preview validator
+        </h2>
+        <Badge variant='outline'>Unsigned preview</Badge>
+      </div>
+      <ol className='grid list-inside list-decimal gap-4 text-sm md:grid-cols-3'>
+        <li>
+          <span className='font-medium'>Open the local operator app</span>
+          <p className='mt-2 text-muted-foreground'>
+            Windows: open the executable and choose Open local operator app.
+            Linux and macOS: run <code>aipg-validator app</code>.
+          </p>
+        </li>
+        <li>
+          <span className='font-medium'>Set up node</span>
+          <p className='mt-2 text-muted-foreground'>
+            Approve a new dedicated identity on that machine. Keep existing
+            configuration when upgrading. Never enter a funded wallet&apos;s
+            private key.
+          </p>
+        </li>
+        <li>
+          <span className='font-medium'>Start validator</span>
+          <p className='mt-2 text-muted-foreground'>
+            Check registration, recent heartbeats, and accepted evidence in the
+            local app. Google login and a Console key are not required.
+          </p>
+        </li>
+      </ol>
+      <div className='flex flex-wrap gap-3'>
+        <Button asChild variant='outline' size='sm'>
+          <a href='https://aipowergrid.io/validate'>
+            <Download className='mr-2 h-4 w-4' />
+            Downloads
+          </a>
+        </Button>
+        <Button asChild variant='outline' size='sm'>
+          <a href='https://aipowergrid.io/docs/validator-node'>
+            <ExternalLink className='mr-2 h-4 w-4' />
+            Setup guide
+          </a>
+        </Button>
+      </div>
+    </section>
+  );
+}

--- a/src/features/validators/components/validator-pairing.tsx
+++ b/src/features/validators/components/validator-pairing.tsx
@@ -1,0 +1,232 @@
+// SPDX-FileCopyrightText: 2026 AI Power Grid
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useSession } from 'next-auth/react';
+import { CheckCircle2, Link2, RefreshCw, ShieldCheck } from 'lucide-react';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import {
+  PairingRequestError,
+  PairingView,
+  pairingViewSchema,
+  readPairingResponse
+} from '@/lib/validator-pairing';
+import { PairingStepUp } from './pairing-step-up';
+
+export default function ValidatorPairing({ pairingId }: { pairingId: string }) {
+  const { data: session } = useSession();
+  const [view, setView] = useState<PairingView | null>(null);
+  const [error, setError] = useState<PairingRequestError | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [busy, setBusy] = useState(false);
+  const [revision, setRevision] = useState(0);
+  const [now, setNow] = useState(() => Date.now());
+  const path = `/api/validator-pairings/${pairingId}`;
+  const returnTo = `/dashboard/connect-validator/${pairingId}`;
+  const expired =
+    !!view && view.status !== 'linked' && now >= view.expires_at * 1000;
+
+  useEffect(() => {
+    const timer = window.setInterval(() => setNow(Date.now()), 1000);
+    return () => window.clearInterval(timer);
+  }, []);
+
+  useEffect(() => {
+    if (busy) return;
+    const controller = new AbortController();
+    let timer: ReturnType<typeof setTimeout>;
+    async function load() {
+      try {
+        const next = await readPairingResponse(
+          await fetch(path, { cache: 'no-store', signal: controller.signal }),
+          pairingViewSchema.refine((item) => item.pairing_id === pairingId)
+        );
+        if (controller.signal.aborted) return;
+        setView(next);
+        setError(null);
+        if (
+          ['pending', 'approved'].includes(next.status) &&
+          Date.now() < next.expires_at * 1000
+        ) {
+          timer = setTimeout(load, 5000);
+        }
+      } catch (err) {
+        if (controller.signal.aborted) return;
+        setView(null);
+        setError(
+          err instanceof PairingRequestError
+            ? err
+            : new PairingRequestError(502)
+        );
+      } finally {
+        if (!controller.signal.aborted) setLoading(false);
+      }
+    }
+    void load();
+    return () => {
+      controller.abort();
+      clearTimeout(timer);
+    };
+  }, [path, pairingId, revision, busy]);
+
+  async function approve() {
+    if (!view || view.status !== 'pending' || expired || busy) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const next = await readPairingResponse(
+        await fetch(`${path}/approve`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: '{}',
+          cache: 'no-store'
+        }),
+        pairingViewSchema.refine((item) => item.pairing_id === pairingId)
+      );
+      setView(next);
+    } catch (err) {
+      setView(null);
+      setError(
+        err instanceof PairingRequestError ? err : new PairingRequestError(502)
+      );
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <section className='mx-auto w-full min-w-0 max-w-2xl space-y-6 py-4'>
+      <header className='space-y-2'>
+        <div className='flex flex-wrap items-center gap-2'>
+          <Link2 className='h-5 w-5 text-primary' aria-hidden='true' />
+          <h1 className='text-2xl font-semibold'>Link validator</h1>
+          <Badge variant='outline'>Account visibility only</Badge>
+        </div>
+        <p className='break-words text-sm text-muted-foreground'>
+          AIPG account:{' '}
+          {session?.user?.email ?? session?.user?.name ?? 'Signed in'}
+        </p>
+      </header>
+
+      {loading && (
+        <p role='status' className='text-sm'>
+          Checking request...
+        </p>
+      )}
+      {error && (
+        <div className='space-y-4'>
+          <Alert variant='destructive'>
+            <AlertTitle>Link not confirmed</AlertTitle>
+            <AlertDescription>{error.message}</AlertDescription>
+          </Alert>
+          {[401, 403].includes(error.status) && (
+            <PairingStepUp returnTo={returnTo} />
+          )}
+          <Button
+            variant='outline'
+            onClick={() => {
+              setLoading(true);
+              setRevision((value) => value + 1);
+            }}
+          >
+            <RefreshCw className='mr-2 h-4 w-4' />
+            Retry
+          </Button>
+        </div>
+      )}
+
+      {view && (
+        <>
+          <dl className='grid gap-4 border-y py-5 text-sm sm:grid-cols-[8rem_minmax(0,1fr)]'>
+            <dt className='text-muted-foreground'>Validator</dt>
+            <dd className='min-w-0 break-all font-mono'>{view.validator_id}</dd>
+            <dt className='text-muted-foreground'>Node signer</dt>
+            <dd className='min-w-0 break-all font-mono'>
+              {view.signing_wallet}
+            </dd>
+            <dt className='text-muted-foreground'>Status</dt>
+            <dd className='capitalize' role='status'>
+              {expired ? 'Expired' : view.status}
+            </dd>
+            {view.status !== 'linked' && (
+              <>
+                <dt className='text-muted-foreground'>Time remaining</dt>
+                <dd className='tabular-nums'>
+                  {Math.max(
+                    0,
+                    Math.ceil((view.expires_at * 1000 - now) / 1000)
+                  )}{' '}
+                  seconds
+                </dd>
+              </>
+            )}
+          </dl>
+
+          {view.status === 'pending' && !expired && (
+            <div className='space-y-4'>
+              <p className='text-sm'>
+                Approve only a request you started on your own validator. Its
+                status will become visible in this account. No keys, funds,
+                payout wallets, or node controls are transferred.
+              </p>
+              <Button onClick={approve} disabled={busy}>
+                <ShieldCheck className='mr-2 h-4 w-4' />
+                {busy ? 'Approving...' : 'Approve this node'}
+              </Button>
+            </div>
+          )}
+
+          {view.status === 'approved' && !expired && (
+            <div className='space-y-4'>
+              <h2 className='text-lg font-semibold'>
+                Confirm in your local app
+              </h2>
+              <p className='text-sm'>
+                Compare this code with the code on your validator machine.
+                Confirm there only if both codes match. If not, cancel in the
+                local app.
+              </p>
+              <output
+                aria-label='Comparison code'
+                className='block break-all font-mono text-3xl font-semibold'
+              >
+                {view.comparison_code}
+              </output>
+              <p role='status' className='text-sm text-muted-foreground'>
+                Waiting for your node to confirm...
+              </p>
+            </div>
+          )}
+
+          {view.status === 'linked' && (
+            <div className='flex items-start gap-3' role='status'>
+              <CheckCircle2 className='mt-0.5 h-5 w-5 shrink-0 text-emerald-600' />
+              <div>
+                <h2 className='font-semibold'>Validator linked</h2>
+                <p className='mt-1 text-sm text-muted-foreground'>
+                  Node keys and operation are unchanged.
+                </p>
+              </div>
+            </div>
+          )}
+          {(expired || ['cancelled', 'expired'].includes(view.status)) && (
+            <p className='text-sm'>
+              This request is closed. Check your linked nodes before starting
+              again in the local app.
+            </p>
+          )}
+        </>
+      )}
+      <a
+        className='inline-block text-sm text-primary underline underline-offset-4'
+        href='/dashboard/validators'
+      >
+        View linked nodes
+      </a>
+    </section>
+  );
+}

--- a/src/features/validators/components/validator-scorecards-view.tsx
+++ b/src/features/validators/components/validator-scorecards-view.tsx
@@ -4,18 +4,13 @@ import { useEffect, useMemo, useState } from 'react';
 import {
   Activity,
   CheckCircle2,
-  Copy,
-  Download,
   Gauge,
   GitBranch,
-  KeyRound,
   RefreshCw,
   ShieldAlert,
   ShieldCheck,
-  Terminal,
   Timer,
-  Users,
-  WalletCards
+  Users
 } from 'lucide-react';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Badge } from '@/components/ui/badge';
@@ -33,6 +28,8 @@ import {
   TableHeader,
   TableRow
 } from '@/components/ui/table';
+import ValidatorOnboarding from './validator-onboarding';
+import LinkedValidators from './linked-validators';
 
 type WindowHours = 24 | 168 | 720;
 type AuthorityMode = 'all' | 'authoritative' | 'preview';
@@ -173,11 +170,6 @@ interface AssignmentHealthResponse {
   error?: string;
 }
 
-interface AccountInfo {
-  account_id: string;
-  wallet: string | null;
-}
-
 const WINDOWS: { label: string; value: WindowHours }[] = [
   { label: '24h', value: 24 },
   { label: '7d', value: 168 },
@@ -280,68 +272,6 @@ export default function ValidatorScorecardsView() {
   const [health, setHealth] = useState<AssignmentHealthResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
-  const [account, setAccount] = useState<AccountInfo | null>(null);
-  const [accountLoading, setAccountLoading] = useState(true);
-  const [keyCreating, setKeyCreating] = useState(false);
-  const [validatorKey, setValidatorKey] = useState('');
-  const [keyCopied, setKeyCopied] = useState(false);
-  const [onboardingError, setOnboardingError] = useState('');
-
-  useEffect(() => {
-    let cancelled = false;
-    fetch('/api/account', { cache: 'no-store' })
-      .then(async (res) => {
-        if (!res.ok) throw new Error('Grid account unavailable');
-        return (await res.json()) as AccountInfo;
-      })
-      .then((next) => {
-        if (!cancelled) setAccount(next);
-      })
-      .catch(() => {
-        if (!cancelled)
-          setOnboardingError('Sign in again to prepare a validator.');
-      })
-      .finally(() => {
-        if (!cancelled) setAccountLoading(false);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, []);
-
-  async function createValidatorKey() {
-    setKeyCreating(true);
-    setOnboardingError('');
-    try {
-      const res = await fetch('/api/account/keys', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          label: `validator-${new Date().toISOString().slice(0, 10)}`,
-          purpose: 'validator'
-        })
-      });
-      const body = await res.json();
-      if (!res.ok || !body?.api_key) {
-        throw new Error(body?.detail || body?.error || 'Key creation failed');
-      }
-      setValidatorKey(body.api_key);
-    } catch (err) {
-      setOnboardingError(
-        err instanceof Error ? err.message : 'Validator key creation failed'
-      );
-    } finally {
-      setKeyCreating(false);
-    }
-  }
-
-  async function copyValidatorKey() {
-    if (!validatorKey) return;
-    await navigator.clipboard.writeText(validatorKey);
-    setKeyCopied(true);
-    window.setTimeout(() => setKeyCopied(false), 1500);
-  }
-
   useEffect(() => {
     let cancelled = false;
     async function load() {
@@ -478,6 +408,9 @@ export default function ValidatorScorecardsView() {
         }
       />
 
+      <ValidatorOnboarding />
+      <LinkedValidators />
+
       <Alert>
         <ShieldCheck className='h-4 w-4' />
         <AlertTitle>Preview evidence, no rewards yet</AlertTitle>
@@ -562,131 +495,6 @@ export default function ValidatorScorecardsView() {
               </div>
             </div>
           </div>
-        </CardContent>
-      </Card>
-
-      <Card>
-        <CardContent className='space-y-6 p-5'>
-          <div className='flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between'>
-            <div>
-              <h2 className='font-semibold'>Run a preview validator</h2>
-              <p className='mt-1 max-w-3xl text-sm text-muted-foreground'>
-                A CPU-only validator receives short-lived Grid assignments,
-                probes the assigned worker, and signs the resulting evidence.
-                Missing assignments fail closed; the node does not probe random
-                production traffic.
-              </p>
-            </div>
-            <Badge variant='outline'>Unsigned preview</Badge>
-          </div>
-
-          <div className='grid gap-px overflow-hidden rounded-md border bg-border sm:grid-cols-2 xl:grid-cols-4'>
-            <div className='space-y-3 bg-background p-5'>
-              <div className='flex items-center gap-2 font-medium'>
-                <Download className='h-4 w-4 text-emerald-500' />
-                1. Install and prepare
-              </div>
-              <p className='text-sm text-muted-foreground'>
-                Install the exact preview, then create the signing identity on
-                the validator machine. The private key is never sent here.
-              </p>
-              <Button asChild variant='outline' size='sm'>
-                <a href='https://aipowergrid.io/validate'>View downloads</a>
-              </Button>
-              <code className='block break-all rounded bg-muted px-3 py-2 text-xs'>
-                aipg-validator prepare-wallet
-              </code>
-            </div>
-
-            <div className='space-y-3 bg-background p-5'>
-              <div className='flex items-center gap-2 font-medium'>
-                <WalletCards className='h-4 w-4 text-orange-500' />
-                2. Link the public address
-              </div>
-              <p className='text-sm text-muted-foreground'>
-                Link the address printed by the validator. Never paste its
-                private key into the Console or send it to anyone.
-              </p>
-              {accountLoading ? (
-                <Skeleton className='h-9 w-full' />
-              ) : account?.wallet ? (
-                <code className='block break-all rounded bg-muted px-3 py-2 text-xs'>
-                  {account.wallet}
-                </code>
-              ) : (
-                <Button asChild variant='outline' size='sm'>
-                  <a href='/dashboard/settings'>Link wallet</a>
-                </Button>
-              )}
-            </div>
-
-            <div className='space-y-3 bg-background p-5'>
-              <div className='flex items-center gap-2 font-medium'>
-                <KeyRound className='h-4 w-4 text-sky-500' />
-                3. Create a validator key
-              </div>
-              <p className='text-sm text-muted-foreground'>
-                This key can only read assignments, probe, attest, and read
-                validator status. It cannot submit inference or manage funds.
-              </p>
-              <Button
-                type='button'
-                size='sm'
-                onClick={createValidatorKey}
-                disabled={
-                  keyCreating || !account?.wallet || Boolean(validatorKey)
-                }
-              >
-                {keyCreating
-                  ? 'Creating…'
-                  : validatorKey
-                    ? 'Key created'
-                    : 'Create key'}
-              </Button>
-            </div>
-
-            <div className='space-y-3 bg-background p-5'>
-              <div className='flex items-center gap-2 font-medium'>
-                <Terminal className='h-4 w-4 text-violet-500' />
-                4. Initialize and check
-              </div>
-              <p className='text-sm text-muted-foreground'>
-                Paste the one-time validator key into local setup, then verify
-                registration before leaving the node online.
-              </p>
-              <div className='space-y-1 text-xs'>
-                <code className='block'>aipg-validator init</code>
-                <code className='block'>aipg-validator check --no-probe</code>
-                <code className='block'>aipg-validator run</code>
-              </div>
-            </div>
-          </div>
-
-          {validatorKey ? (
-            <div className='space-y-3 rounded-md border border-emerald-500/30 bg-emerald-500/5 p-4'>
-              <p className='text-sm font-medium text-emerald-600 dark:text-emerald-400'>
-                Copy this key now. Core stores only its hash.
-              </p>
-              <div className='flex flex-col gap-2 sm:flex-row'>
-                <code className='min-w-0 flex-1 overflow-x-auto rounded bg-background px-3 py-2 text-xs'>
-                  {validatorKey}
-                </code>
-                <Button
-                  type='button'
-                  variant='secondary'
-                  size='sm'
-                  onClick={copyValidatorKey}
-                >
-                  <Copy className='mr-2 h-4 w-4' />
-                  {keyCopied ? 'Copied' : 'Copy'}
-                </Button>
-              </div>
-            </div>
-          ) : null}
-
-          {onboardingError ? (
-            <p className='text-sm text-destructive'>{onboardingError}</p>
-          ) : null}
         </CardContent>
       </Card>
 

--- a/src/hooks/use-breadcrumbs.tsx
+++ b/src/hooks/use-breadcrumbs.tsx
@@ -27,6 +27,10 @@ export function useBreadcrumbs() {
   const pathname = usePathname();
 
   const breadcrumbs = useMemo(() => {
+    // Pairing IDs are opaque handles, not useful navigation labels.
+    if (/^\/dashboard\/connect-validator\/vpa_[0-9a-f]{64}$/.test(pathname)) {
+      return [{ title: 'Link validator', link: pathname }];
+    }
     // Check if we have a custom mapping for this exact path
     if (routeMapping[pathname]) {
       return routeMapping[pathname];

--- a/src/lib/AGENTS.md
+++ b/src/lib/AGENTS.md
@@ -18,6 +18,9 @@ provisioning helpers, search parameters, and small shared utilities.
 - `grid-account.ts` — server-side Grid account/session provisioning helpers.
 - `safe-callback-url.ts` — same-origin post-auth navigation guard. Use it for
   any browser-controlled Auth.js callback; Web3 sign-in redirects manually.
+- `validator-pairing.ts` - shared Zod display schemas and safe error messages.
+  Contains no credentials or signing logic; strips node-only payloads at the
+  BFF. Core remains authoritative for proof, ownership and state transitions.
 - `searchparams.ts` — nuqs URL search-param parsers. `utils.ts` — `cn` + misc helpers.
 
 ## Local Contracts
@@ -28,6 +31,9 @@ provisioning helpers, search parameters, and small shared utilities.
 - Token refresh must preserve the session's canonical `gridAccountId`. If a
   service exchange returns a different account, fail closed and require a new
   proof-backed login; never move a live Console session to another balance.
+- `resolveGridKey` never follows a service-exchange redirect. Callers may pass
+  an abort signal; validator pairing includes refresh in its ten-second Core
+  deadline instead of timing only the later metadata request.
 - `gridSession` / wallet verify **soft-fail** (return `null`): a grid outage degrades key
   features but must not break sign-in.
 - `grid-api.ts` is the only place that constructs grid URLs/headers — route handlers call

--- a/src/lib/grid-account.ts
+++ b/src/lib/grid-account.ts
@@ -45,7 +45,10 @@ export async function getSessionToken(req: NextRequest): Promise<any | null> {
  *
  * Returns null only when there's no usable identity at all.
  */
-export async function resolveGridKey(token: any): Promise<string | null> {
+export async function resolveGridKey(
+  token: any,
+  signal?: AbortSignal
+): Promise<string | null> {
   const existing = (token?.gridAccessToken ?? token?.gridApiKey) as
     | string
     | undefined;
@@ -67,7 +70,9 @@ export async function resolveGridKey(token: any): Promise<string | null> {
       body: JSON.stringify({
         subject: providerId
       }),
-      cache: 'no-store'
+      cache: 'no-store',
+      redirect: 'error',
+      signal
     });
     if (!res.ok) return null;
     const data = await res.json();

--- a/src/lib/validator-pairing.ts
+++ b/src/lib/validator-pairing.ts
@@ -1,0 +1,88 @@
+// SPDX-FileCopyrightText: 2026 AI Power Grid
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { z } from 'zod';
+
+export const pairingIdSchema = z.string().regex(/^vpa_[0-9a-f]{64}$/);
+export const validatorIdSchema = z.string().regex(/^val_[0-9a-f]{32}$/);
+const walletSchema = z.string().regex(/^0x[0-9a-fA-F]{40}$/);
+
+// Strip the node-only signing payload and any future credentials at the BFF.
+export const pairingViewSchema = z
+  .object({
+    pairing_id: pairingIdSchema,
+    validator_id: validatorIdSchema,
+    signing_wallet: walletSchema,
+    status: z.enum(['pending', 'approved', 'linked', 'expired', 'cancelled']),
+    expires_at: z.number().int().positive(),
+    economic_effect: z.literal('none'),
+    comparison_code: z
+      .string()
+      .regex(/^[0-9A-F]{8}$/)
+      .optional()
+  })
+  .refine(
+    (view) =>
+      !['approved', 'linked'].includes(view.status) || !!view.comparison_code,
+    'Approved pairing requires a comparison code'
+  );
+
+export const linkedValidatorsSchema = z.object({
+  economic_effect: z.literal('none'),
+  nodes: z
+    .array(
+      z.object({
+        validator_id: validatorIdSchema,
+        pairing_id: pairingIdSchema,
+        signing_wallet: walletSchema,
+        status: z.string().min(1).max(64),
+        software_version: z.string().max(128).nullable(),
+        last_heartbeat: z.string().datetime({ offset: true }).nullable(),
+        linked_at: z.string().datetime({ offset: true })
+      })
+    )
+    .max(100)
+});
+
+export const unlinkValidatorSchema = z
+  .object({ pairing_id: pairingIdSchema })
+  .strict();
+export type PairingView = z.infer<typeof pairingViewSchema>;
+export type LinkedValidator = z.infer<
+  typeof linkedValidatorsSchema
+>['nodes'][number];
+
+export class PairingRequestError extends Error {
+  constructor(public readonly status: number) {
+    super(pairingErrorMessage(status));
+    this.name = 'PairingRequestError';
+  }
+}
+
+export function pairingErrorMessage(status: number): string {
+  switch (status) {
+    case 401:
+    case 403:
+      return 'Confirm your account with Google or a wallet, then retry.';
+    case 404:
+      return 'This association request was not found. Check your linked nodes or start again in the local app.';
+    case 409:
+      return 'This request expired, changed, or was approved by another account. Check your linked nodes before starting again.';
+    case 429:
+      return 'Too many requests. Wait a minute, then retry.';
+    case 503:
+      return 'Account linking is unavailable. Your validator can keep running without it.';
+    default:
+      return 'Could not reach account linking. Retry without creating a new node.';
+  }
+}
+
+export async function readPairingResponse<T>(
+  response: Response,
+  schema: z.ZodType<T>
+): Promise<T> {
+  if (!response.ok) throw new PairingRequestError(response.status);
+  const parsed = schema.safeParse(await response.json());
+  if (!parsed.success) throw new PairingRequestError(502);
+  return parsed.data;
+}


### PR DESCRIPTION
## What and why
Adds the Console counterpart to AIPowerGrid/grid-core#58. A separately enrolled node can request an optional private association to the operator account. Human approval is explicit; a comparison code and separate local-node confirmation are still required. No node key, signing payload, account merge, payout right, or validator authority enters the Console.

Replaces obsolete manual wallet/API-key onboarding with the released local operator-app path. Adds private linked-node status and exact-association removal. Existing aggregate evidence and economic boundaries are preserved.

## Security
- Encrypted-session user token only; no inbound credential override or service-key fallback.
- Strict IDs and JSON bodies, exact-origin writes, no-store/no-referrer, framing denied on consent page.
- Bounded metadata responses, sanitized errors, no credential-bearing redirects.
- Ten-second deadline includes token refresh; canonical-account mismatch fails closed.
- Login and polling never approve or remove a node.

## Verification
Frozen pnpm install, strict lint, formatting, production build, existing canonical-account/credits smoke, and new production-server pairing smoke passed. New tests cover anonymous/forged auth, origin/Fetch Metadata, fixed and chunked body bounds, immutable request IDs, field stripping, error/redirect/timeout paths, refresh failures, explicit mutations, and page protection. Browser mock-flow QA covered pending/approved/separately confirmed/linked, removal cancellation, expiry, reauthentication and unavailable states; consent and removal layouts checked at 320/390/1280px. Staged secret scan and 130-commit reachable history clean.

## Rollout and remaining gates
DRAFT ONLY: not merged or deployed. Core pairing remains disabled. Local-app pairing controls, real Windows/Linux two-sided signing proof, coordinated Core migration 0030, and a supervised canary remain required. Preview.12 does not yet implement pairing. Mock node confirmation is not a production or cryptographic end-to-end claim. No validator economics, paid audit, media issuance or contracts changed.