### PR TITLE
fix(console): recover API key management after stale sign-in

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,5 +34,7 @@ jobs:
         run: pnpm build
       - name: Test canonical account boundary
         run: pnpm test:auth-smoke
+      - name: Test key-management proof boundary
+        run: pnpm test:key-management
       - name: Test validator account pairing boundary
         run: pnpm test:validator-pairing

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,7 +105,8 @@ described as deployable until the build and Worker configuration land together.
 - `Console CI / verify` runs the same checks on pushes and pull requests to
   `master` without production credentials.
 - `pnpm test:key-management` verifies key creation/revocation against a local
-  mock Core after building, including expired proof and service-refresh denial.
+  mock Core after building, including bounded pending-creation retry, canceled
+  reauthentication, expired proof, failure statuses, and service-refresh denial.
   `pnpm test:key-management --ui` starts a local-only fixture for browser QA;
   its fake sessions and keys must never enter production routes or configuration.
 - `pnpm test:validator-pairing` exercises protected pairing routes against a

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,6 +104,10 @@ described as deployable until the build and Worker configuration land together.
   credit passthrough, anonymous rejection, and account-mismatch failure.
 - `Console CI / verify` runs the same checks on pushes and pull requests to
   `master` without production credentials.
+- `pnpm test:key-management` verifies key creation/revocation against a local
+  mock Core after building, including expired proof and service-refresh denial.
+  `pnpm test:key-management --ui` starts a local-only fixture for browser QA;
+  its fake sessions and keys must never enter production routes or configuration.
 - `pnpm test:validator-pairing` exercises protected pairing routes against a
   local mock Core after the build. Account association remains default off in
   Core until the node client and supervised rollout are complete.

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "lint:fix": "eslint src --fix && pnpm format",
     "lint:strict": "eslint --max-warnings=0 src",
     "test:auth-smoke": "node scripts/auth-smoke.mjs",
+    "test:key-management": "node scripts/key-management-smoke.mjs",
     "test:validator-pairing": "node scripts/validator-pairing-smoke.mjs",
     "format": "prettier --write .",
     "format:check": "prettier --check .",

--- a/scripts/key-management-smoke.mjs
+++ b/scripts/key-management-smoke.mjs
@@ -6,6 +6,11 @@ import { spawn } from 'node:child_process';
 import { once } from 'node:events';
 import http from 'node:http';
 import { encode } from 'next-auth/jwt';
+import {
+  PENDING_KEY_CREATION_KEY,
+  rememberPendingKeyCreation,
+  takePendingKeyCreation
+} from '../src/features/api-key/lib/pending-key-creation.mjs';
 
 const appOrigin = 'http://127.0.0.1:18896';
 const coreOrigin = 'http://127.0.0.1:18897';
@@ -29,6 +34,31 @@ const keys = [
     revoked: false
   }
 ];
+
+function memoryStorage() {
+  const values = new Map();
+  return {
+    getItem: (key) => values.get(key) ?? null,
+    setItem: (key, value) => values.set(key, String(value)),
+    removeItem: (key) => values.delete(key)
+  };
+}
+
+function verifyPendingIntentContract() {
+  const now = 1_800_000_000_000;
+  const storage = memoryStorage();
+  const intent = { accountId, label: 'reauth-test' };
+  rememberPendingKeyCreation(storage, intent, now);
+  assert.deepEqual(takePendingKeyCreation(storage, now + 1), intent);
+  assert.equal(takePendingKeyCreation(storage, now + 2), null);
+
+  rememberPendingKeyCreation(storage, intent, now);
+  assert.equal(takePendingKeyCreation(storage, now + 10 * 60 * 1000 + 1), null);
+  storage.setItem(PENDING_KEY_CREATION_KEY, '{not-json');
+  assert.equal(takePendingKeyCreation(storage, now), null);
+}
+
+verifyPendingIntentContract();
 
 async function cookie(fresh = false, expired = false) {
   const value = await encode({
@@ -175,7 +205,12 @@ app.stderr.on('data', (chunk) => {
   appOutput = (appOutput + chunk).slice(-16_000);
 });
 
-async function request(path, session = '', method = 'GET') {
+async function request(
+  path,
+  session = '',
+  method = 'GET',
+  label = 'new-test-key'
+) {
   return fetch(`${appOrigin}${path}`, {
     method,
     headers: {
@@ -183,9 +218,7 @@ async function request(path, session = '', method = 'GET') {
       Origin: appOrigin,
       'Content-Type': 'application/json'
     },
-    ...(method === 'POST'
-      ? { body: JSON.stringify({ label: 'new-test-key' }) }
-      : {}),
+    ...(method === 'POST' ? { body: JSON.stringify({ label }) } : {}),
     signal: AbortSignal.timeout(15_000),
     redirect: 'manual'
   });
@@ -250,19 +283,50 @@ try {
     overrideStatus = 0;
     assert.equal((await request('/api/account', fresh)).status, 200);
     assert.equal(writes, 0, 'sign-in and reads never retry a mutation');
-    const created = await request('/api/account/keys', fresh, 'POST');
+
+    const canceledStorage = memoryStorage();
+    rememberPendingKeyCreation(canceledStorage, {
+      accountId,
+      label: 'canceled-reauth'
+    });
+    const canceled = takePendingKeyCreation(canceledStorage);
+    assert.ok(canceled);
+    assert.equal(
+      (await request('/api/account/keys', stale, 'POST', canceled.label))
+        .status,
+      403
+    );
+    assert.equal(writes, 0, 'canceled reauth cannot create a key');
+    assert.equal(takePendingKeyCreation(canceledStorage), null);
+
+    const retryStorage = memoryStorage();
+    rememberPendingKeyCreation(retryStorage, {
+      accountId,
+      label: 'reauth-test'
+    });
+    const pending = takePendingKeyCreation(retryStorage);
+    assert.ok(pending);
+    assert.equal(pending.accountId, accountId);
+    const created = await request(
+      '/api/account/keys',
+      fresh,
+      'POST',
+      pending.label
+    );
     assert.equal(created.status, 200);
     assert.equal(
       (await created.json()).api_key,
       'local-fixture-key-not-a-credential'
     );
     assert.equal(writes, 1);
+    assert.equal(keys.at(-1)?.label, 'reauth-test');
+    assert.equal(takePendingKeyCreation(retryStorage), null);
     assert.equal((await request(keyPath, fresh, 'DELETE')).status, 200);
     assert.equal(keys[0].revoked, true);
     assert.equal(writes, 2);
     assert.equal(mockErrors.length, 0, String(mockErrors[0] ?? ''));
     console.log(
-      'Key-management anonymous, fresh-proof, service-refresh, failure and explicit-mutation smoke passed'
+      'Key-management pending-reauth, canceled-reauth, fresh-proof, service-refresh and failure smoke passed'
     );
   }
 } finally {

--- a/scripts/key-management-smoke.mjs
+++ b/scripts/key-management-smoke.mjs
@@ -1,0 +1,278 @@
+// SPDX-FileCopyrightText: 2026 AI Power Grid
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { once } from 'node:events';
+import http from 'node:http';
+import { encode } from 'next-auth/jwt';
+
+const appOrigin = 'http://127.0.0.1:18896';
+const coreOrigin = 'http://127.0.0.1:18897';
+const authSecret = 'key-management-local-test-secret-only';
+const cookieName = 'authjs.session-token';
+const accountId = '00000000-0000-0000-0000-000000000123';
+const keyId = 'abcdef123456';
+const keyPath = `/api/account/keys/${keyId}`;
+const ui = process.argv.includes('--ui');
+let overrideStatus = 0;
+let exchangeCalls = 0;
+let writes = 0;
+const calls = [];
+const mockErrors = [];
+const keys = [
+  {
+    id: keyId,
+    label: 'test-laptop',
+    created: null,
+    last_used: null,
+    revoked: false
+  }
+];
+
+async function cookie(fresh = false, expired = false) {
+  const value = await encode({
+    token: {
+      sub: 'key-test-user',
+      provider_id: 'google_key-test-user',
+      name: 'Local key test',
+      email: 'operator@example.test',
+      gridAccountId: accountId,
+      gridAccessToken: fresh ? 'key-test-fresh-proof' : 'key-test-read-only',
+      gridAccessTokenExpiresAt: expired ? Date.now() - 1 : Date.now() + 600_000
+    },
+    secret: authSecret,
+    salt: cookieName,
+    maxAge: 3600
+  });
+  return `${cookieName}=${value}`;
+}
+
+function json(response, status, value) {
+  response.writeHead(status, { 'Content-Type': 'application/json' });
+  response.end(JSON.stringify(value));
+}
+
+const core = http.createServer(async (request, response) => {
+  try {
+    // Local-only fixture: the test server, not the production app, issues the
+    // fake session. No real OAuth, account, API key, or paid job is involved.
+    if (ui && request.url?.startsWith('/__test/')) {
+      if (['/__test/stale', '/__test/fresh'].includes(request.url)) {
+        response.writeHead(302, {
+          'Set-Cookie': `${await cookie(request.url.endsWith('/fresh'))}; HttpOnly; SameSite=Lax; Path=/`,
+          Location: `${appOrigin}/dashboard/api-key`
+        });
+        return response.end();
+      }
+      if (request.method === 'POST') {
+        overrideStatus = request.url === '/__test/unavailable' ? 503 : 0;
+        response.writeHead(302, { Location: '/__test/' });
+        return response.end();
+      }
+      response.writeHead(200, { 'Content-Type': 'text/html' });
+      return response.end(`<h1>Local key-management fixture</h1>
+        <p>No production accounts. Successful mutations: ${writes}.</p>
+        <a href="/__test/stale">Open stale-proof session</a><br>
+        <a href="/__test/fresh">Open fresh-proof session</a>
+        <form method="post" action="/__test/unavailable"><button>Core unavailable</button></form>
+        <form method="post" action="/__test/normal"><button>Core normal</button></form>`);
+    }
+    const chunks = [];
+    for await (const chunk of request) chunks.push(chunk);
+    const body = chunks.length
+      ? JSON.parse(Buffer.concat(chunks).toString('utf8'))
+      : {};
+    if (request.url === '/v1/auth/service/exchange') {
+      assert.equal(request.headers.apikey, 'key-test-service-token');
+      assert.equal(body.subject, 'google_key-test-user');
+      exchangeCalls++;
+      return json(response, 200, {
+        access_token: 'key-test-read-only',
+        account_id: accountId,
+        expires_in: 900
+      });
+    }
+    if (!request.url?.startsWith('/v1/account')) return json(response, 404, {});
+    const token = request.headers.apikey;
+    assert.ok(['key-test-fresh-proof', 'key-test-read-only'].includes(token));
+    assert.equal(request.headers.authorization, undefined);
+    calls.push({ method: request.method, path: request.url, token });
+    if (request.method === 'GET' && request.url === '/v1/account') {
+      return json(response, 200, {
+        account_id: accountId,
+        username: 'Local test',
+        wallet: '',
+        keys
+      });
+    }
+    if (overrideStatus)
+      return json(response, overrideStatus, { detail: 'mock upstream error' });
+    if (token !== 'key-test-fresh-proof')
+      return json(response, 403, {
+        detail: 'Account proof is stale; sign in again'
+      });
+    if (request.method === 'POST' && request.url === '/v1/account/keys') {
+      writes++;
+      keys.push({
+        id: 'feed12345678',
+        label: body.label,
+        created: null,
+        last_used: null,
+        revoked: false
+      });
+      return json(response, 200, {
+        api_key: 'local-fixture-key-not-a-credential'
+      });
+    }
+    if (
+      request.method === 'DELETE' &&
+      request.url === `/v1/account/keys/${keyId}`
+    ) {
+      writes++;
+      keys[0].revoked = true;
+      return json(response, 200, { revoked: true });
+    }
+    return json(response, 404, {});
+  } catch (error) {
+    mockErrors.push(error);
+    return json(response, 500, { error: 'mock assertion failed' });
+  }
+});
+
+await new Promise((resolve, reject) => {
+  core.once('error', reject);
+  core.listen(18897, '127.0.0.1', resolve);
+});
+const app = spawn(
+  process.execPath,
+  [
+    'node_modules/next/dist/bin/next',
+    'start',
+    '--hostname',
+    '127.0.0.1',
+    '--port',
+    '18896'
+  ],
+  {
+    env: {
+      ...process.env,
+      AUTH_SECRET: authSecret,
+      NEXTAUTH_SECRET: authSecret,
+      AUTH_TRUST_HOST: 'true',
+      NEXTAUTH_URL: appOrigin,
+      GRID_API_BASE: coreOrigin,
+      GRID_SERVICE_API_KEY: 'key-test-service-token'
+    },
+    stdio: ['ignore', 'pipe', 'pipe']
+  }
+);
+let appOutput = '';
+app.stdout.on('data', (chunk) => {
+  appOutput = (appOutput + chunk).slice(-16_000);
+});
+app.stderr.on('data', (chunk) => {
+  appOutput = (appOutput + chunk).slice(-16_000);
+});
+
+async function request(path, session = '', method = 'GET') {
+  return fetch(`${appOrigin}${path}`, {
+    method,
+    headers: {
+      cookie: session,
+      Origin: appOrigin,
+      'Content-Type': 'application/json'
+    },
+    ...(method === 'POST'
+      ? { body: JSON.stringify({ label: 'new-test-key' }) }
+      : {}),
+    signal: AbortSignal.timeout(15_000),
+    redirect: 'manual'
+  });
+}
+
+try {
+  let ready = false;
+  for (let attempt = 0; attempt < 100; attempt++) {
+    try {
+      if ((await request('/api/account')).status === 404) {
+        ready = true;
+        break;
+      }
+    } catch {
+      /* Bounded local-server startup retry. */
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  assert.ok(ready, `Console failed to start: ${appOutput}`);
+  if (ui) {
+    console.log(`Local key fixture: ${coreOrigin}/__test/`);
+    await new Promise((resolve) => {
+      const timer = setTimeout(resolve, 30 * 60 * 1000);
+      for (const signal of ['SIGINT', 'SIGTERM'])
+        process.once(signal, () => {
+          clearTimeout(timer);
+          resolve();
+        });
+    });
+  } else {
+    assert.equal((await request('/api/account/keys', '', 'POST')).status, 404);
+    assert.equal((await request(keyPath, '', 'DELETE')).status, 404);
+    assert.equal(calls.length, 0);
+    assert.equal(exchangeCalls, 0);
+    const stale = await cookie();
+    const fresh = await cookie(true);
+    const expired = await cookie(false, true);
+    assert.equal((await request('/api/account', stale)).status, 200);
+    for (const session of [stale, expired]) {
+      assert.equal(
+        (await request('/api/account/keys', session, 'POST')).status,
+        403
+      );
+      assert.equal((await request(keyPath, session, 'DELETE')).status, 403);
+      assert.equal(writes, 0);
+      assert.equal(keys[0].revoked, false);
+    }
+    assert.equal(
+      exchangeCalls,
+      2,
+      'service refresh cannot upgrade recent-proof authority'
+    );
+    for (const code of [401, 403, 429, 503]) {
+      overrideStatus = code;
+      assert.equal(
+        (await request('/api/account/keys', fresh, 'POST')).status,
+        code
+      );
+      assert.equal((await request(keyPath, fresh, 'DELETE')).status, code);
+      assert.equal(writes, 0);
+    }
+    overrideStatus = 0;
+    assert.equal((await request('/api/account', fresh)).status, 200);
+    assert.equal(writes, 0, 'sign-in and reads never retry a mutation');
+    const created = await request('/api/account/keys', fresh, 'POST');
+    assert.equal(created.status, 200);
+    assert.equal(
+      (await created.json()).api_key,
+      'local-fixture-key-not-a-credential'
+    );
+    assert.equal(writes, 1);
+    assert.equal((await request(keyPath, fresh, 'DELETE')).status, 200);
+    assert.equal(keys[0].revoked, true);
+    assert.equal(writes, 2);
+    assert.equal(mockErrors.length, 0, String(mockErrors[0] ?? ''));
+    console.log(
+      'Key-management anonymous, fresh-proof, service-refresh, failure and explicit-mutation smoke passed'
+    );
+  }
+} finally {
+  if (app.exitCode === null && app.signalCode === null) {
+    const exited = once(app, 'exit');
+    app.kill('SIGTERM');
+    const killTimer = setTimeout(() => app.kill('SIGKILL'), 5000);
+    await exited;
+    clearTimeout(killTimer);
+  }
+  core.closeAllConnections();
+  await new Promise((resolve) => core.close(resolve));
+}

--- a/src/features/AGENTS.md
+++ b/src/features/AGENTS.md
@@ -10,7 +10,11 @@ in `src/app/dashboard/<area>/` stay thin and render the matching feature here.
 - `auth/` — sign-in view + provider buttons (Google, GitHub, Web3). Drives `src/lib/auth`.
 - `overview/` — dashboard home widgets (pie/area/bar graphs, recent models, quick start,
   about-grid) with skeleton variants for the parallel routes under `dashboard/overview/`.
-- `api-key/` — API-key view + account-keys management UI.
+- `api-key/` — API-key view + account-keys management UI. Create/revoke failures
+  remain visible; missing or stale proof offers the existing Google and wallet
+  sign-in controls. Login and list refresh never automatically retry a mutation.
+  Core still decides account-management authority; the UI does not elevate a
+  service-refreshed read token or treat a failed revocation as success.
 - `api-usage/` — usage/metering view. `rewards/` — wallet rewards view.
 - `funding/` — explicit EIP-6963 payment-wallet selection, verified account
   wallet binding, Base balance/gas preflight, guarded asset availability,

--- a/src/features/AGENTS.md
+++ b/src/features/AGENTS.md
@@ -12,7 +12,10 @@ in `src/app/dashboard/<area>/` stay thin and render the matching feature here.
   about-grid) with skeleton variants for the parallel routes under `dashboard/overview/`.
 - `api-key/` — API-key view + account-keys management UI. Create/revoke failures
   remain visible; missing or stale proof offers the existing Google and wallet
-  sign-in controls. Login and list refresh never automatically retry a mutation.
+  sign-in controls. A creation rejected with 401/403 may be remembered in
+  tab-local storage and retried once after fresh proof, only for the same
+  canonical account; consume the intent before sending. Revocation, login,
+  list refresh, account changes, and uncertain failures never retry a mutation.
   Core still decides account-management authority; the UI does not elevate a
   service-refreshed read token or treat a failed revocation as success.
 - `api-usage/` — usage/metering view. `rewards/` — wallet rewards view.

--- a/src/features/api-key/components/account-keys.tsx
+++ b/src/features/api-key/components/account-keys.tsx
@@ -3,7 +3,13 @@
 
 'use client';
 
-import React, { Suspense, useCallback, useEffect, useState } from 'react';
+import React, {
+  Suspense,
+  useCallback,
+  useEffect,
+  useRef,
+  useState
+} from 'react';
 import { RefreshCw } from 'lucide-react';
 import GoogleSignInButton from '@/features/auth/components/google-auth-button';
 import Web3AuthButton from '@/features/auth/components/web3-auth-button';
@@ -12,6 +18,11 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import Link from 'next/link';
+import {
+  clearPendingKeyCreation,
+  rememberPendingKeyCreation,
+  takePendingKeyCreation
+} from '@/features/api-key/lib/pending-key-creation.mjs';
 import {
   Table,
   TableBody,
@@ -35,10 +46,31 @@ interface AccountInfo {
   keys: KeyRow[];
 }
 
+interface PendingCreate {
+  accountId: string;
+  label: string;
+}
+
+function mutationError(status: number, action: 'create' | 'revoke') {
+  if (
+    status === 401 ||
+    status === 403 ||
+    (status === 404 && action === 'create')
+  ) {
+    return 'Sign in again with Google or a linked wallet to manage API keys.';
+  }
+  if (status === 429) return 'Too many requests. Wait a moment and try again.';
+  if (status >= 500)
+    return 'Grid is temporarily unavailable. Refresh the key list before retrying.';
+  return `Could not ${action} this key. Refresh the key list and try again.`;
+}
+
 /**
  * v2 key management: list, create (plaintext shown exactly once), revoke.
  * Account management requires fresh Core-verified Google or wallet proof.
- * Sign-in recovery never retries a mutation automatically.
+ * A definitely rejected creation may be retried once after fresh proof. The
+ * intent is account-bound and consumed before sending; revokes and uncertain
+ * failures always require another explicit click.
  */
 export default function AccountKeys() {
   const [account, setAccount] = useState<AccountInfo | null>(null);
@@ -52,6 +84,10 @@ export default function AccountKeys() {
   const [needsSignIn, setNeedsSignIn] = useState(false);
   const [revoking, setRevoking] = useState<string | null>(null);
   const [refreshing, setRefreshing] = useState(false);
+  const [pendingCreate, setPendingCreate] = useState<PendingCreate | null>(
+    null
+  );
+  const pendingRetryChecked = useRef(false);
 
   const refresh = useCallback(async () => {
     setRefreshing(true);
@@ -59,6 +95,7 @@ export default function AccountKeys() {
       const res = await fetch('/api/account');
       if (res.status === 404) {
         // A readable website session does not guarantee a Core account token.
+        setAccount(null);
         setLegacy(true);
         return;
       }
@@ -73,56 +110,91 @@ export default function AccountKeys() {
     }
   }, []);
 
+  const issueKey = useCallback(
+    async (requestedLabel: string) => {
+      const keyLabel = requestedLabel.trim() || 'api';
+      setCreating(true);
+      setError('');
+      setNeedsSignIn(false);
+      setPendingCreate(null);
+      try {
+        const res = await fetch('/api/account/keys', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ label: keyLabel })
+        });
+        if (!res.ok) {
+          if (
+            (res.status === 401 || res.status === 403 || res.status === 404) &&
+            account
+          ) {
+            setNeedsSignIn(true);
+          }
+          if ((res.status === 401 || res.status === 403) && account) {
+            setPendingCreate({
+              accountId: account.account_id,
+              label: keyLabel
+            });
+          }
+          setError(mutationError(res.status, 'create'));
+          return;
+        }
+        const data = await res.json();
+        if (typeof data.api_key !== 'string' || !data.api_key) {
+          throw new Error('Missing new key');
+        }
+        setPendingCreate(null);
+        setFreshKey(data.api_key);
+        setCopied(false);
+        setLabel('');
+        await refresh();
+      } catch {
+        setError(
+          'Could not confirm key creation. Refresh the key list before trying again.'
+        );
+      } finally {
+        setCreating(false);
+      }
+    },
+    [account, refresh]
+  );
+
   useEffect(() => {
-    refresh();
+    void refresh();
   }, [refresh]);
 
-  function mutationError(status: number, action: 'create' | 'revoke') {
-    if (
-      status === 401 ||
-      status === 403 ||
-      (status === 404 && action === 'create')
-    ) {
-      setNeedsSignIn(true);
-      return 'Sign in again with Google or a linked wallet to manage API keys.';
+  useEffect(() => {
+    if (loading || !account || pendingRetryChecked.current) return;
+    pendingRetryChecked.current = true;
+    const pending = takePendingKeyCreation(window.sessionStorage);
+    if (!pending) return;
+    if (pending.accountId !== account.account_id) {
+      setError(
+        'The signed-in account changed, so the pending key was not created.'
+      );
+      return;
     }
-    if (status === 429)
-      return 'Too many requests. Wait a moment and try again.';
-    if (status >= 500)
-      return 'Grid is temporarily unavailable. Refresh the key list before retrying.';
-    return `Could not ${action} this key. Refresh the key list and try again.`;
+    void issueKey(pending.label);
+  }, [account, issueKey, loading]);
+
+  function createKey(e: React.FormEvent) {
+    e.preventDefault();
+    void issueKey(label);
   }
 
-  async function createKey(e: React.FormEvent) {
-    e.preventDefault();
-    setCreating(true);
-    setError('');
-    setNeedsSignIn(false);
+  function rememberRejectedCreation() {
+    if (!pendingCreate) return;
     try {
-      const res = await fetch('/api/account/keys', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ label: label || 'api' })
-      });
-      if (!res.ok) {
-        setError(mutationError(res.status, 'create'));
-        return;
-      }
-      const data = await res.json();
-      if (typeof data.api_key !== 'string' || !data.api_key) {
-        throw new Error('Missing new key');
-      }
-      setFreshKey(data.api_key);
-      setCopied(false);
-      setLabel('');
-      await refresh();
+      rememberPendingKeyCreation(window.sessionStorage, pendingCreate);
     } catch {
       setError(
-        'Could not confirm key creation. Refresh the key list before trying again.'
+        'Your browser could not preserve the pending request. Sign in, then click Create key again.'
       );
-    } finally {
-      setCreating(false);
     }
+  }
+
+  function forgetRejectedCreation() {
+    clearPendingKeyCreation(window.sessionStorage);
   }
 
   async function revoke(id: string) {
@@ -133,9 +205,11 @@ export default function AccountKeys() {
     setRevoking(id);
     setError('');
     setNeedsSignIn(false);
+    setPendingCreate(null);
     try {
       const res = await fetch(`/api/account/keys/${id}`, { method: 'DELETE' });
       if (!res.ok) {
+        if (res.status === 401 || res.status === 403) setNeedsSignIn(true);
         setError(mutationError(res.status, 'revoke'));
         return;
       }
@@ -170,12 +244,20 @@ export default function AccountKeys() {
           </CardHeader>
           <CardContent className='space-y-3'>
             <p className='text-sm text-muted-foreground'>
-              We couldn&apos;t find a grid account for this session. Sign out
-              and sign back in to provision one, then your API keys will appear
-              here.
+              We couldn&apos;t find a Grid account proof for this session.
+              Continue with the Google account or wallet already linked to your
+              account.
             </p>
-            <Button asChild variant='outline'>
-              <Link href='/api/auth/signout'>Sign out</Link>
+            <Suspense
+              fallback={<p className='text-sm'>Loading sign-in options...</p>}
+            >
+              <div className='grid max-w-sm gap-3 [&_button]:mt-0'>
+                <GoogleSignInButton returnTo='/dashboard/api-key' />
+                <Web3AuthButton returnTo='/dashboard/api-key' />
+              </div>
+            </Suspense>
+            <Button asChild variant='ghost'>
+              <Link href='/api/auth/signout'>Use a different account</Link>
             </Button>
           </CardContent>
         </Card>
@@ -255,14 +337,24 @@ export default function AccountKeys() {
             <div className='max-w-sm space-y-3'>
               <p className='text-sm text-muted-foreground'>
                 Use the Google account or wallet already linked to this account.
-                Signing in does not create or revoke a key.
+                {pendingCreate
+                  ? ' After fresh proof, this rejected creation will retry once.'
+                  : ' After signing in, click Revoke again.'}
               </p>
               <Suspense
                 fallback={<p className='text-sm'>Loading sign-in options...</p>}
               >
                 <div className='grid gap-3 [&_button]:mt-0'>
-                  <GoogleSignInButton returnTo='/dashboard/api-key' />
-                  <Web3AuthButton returnTo='/dashboard/api-key' />
+                  <GoogleSignInButton
+                    returnTo='/dashboard/api-key'
+                    onBeforeSignIn={rememberRejectedCreation}
+                    onSignInFailed={forgetRejectedCreation}
+                  />
+                  <Web3AuthButton
+                    returnTo='/dashboard/api-key'
+                    onBeforeSignIn={rememberRejectedCreation}
+                    onSignInFailed={forgetRejectedCreation}
+                  />
                 </div>
               </Suspense>
             </div>

--- a/src/features/api-key/components/account-keys.tsx
+++ b/src/features/api-key/components/account-keys.tsx
@@ -1,6 +1,12 @@
+// SPDX-FileCopyrightText: 2026 AI Power Grid
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 'use client';
 
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { Suspense, useCallback, useEffect, useState } from 'react';
+import { RefreshCw } from 'lucide-react';
+import GoogleSignInButton from '@/features/auth/components/google-auth-button';
+import Web3AuthButton from '@/features/auth/components/web3-auth-button';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -31,8 +37,8 @@ interface AccountInfo {
 
 /**
  * v2 key management: list, create (plaintext shown exactly once), revoke.
- * Falls back to the legacy single-key generator for sessions that predate
- * grid accounts.
+ * Account management requires fresh Core-verified Google or wallet proof.
+ * Sign-in recovery never retries a mutation automatically.
  */
 export default function AccountKeys() {
   const [account, setAccount] = useState<AccountInfo | null>(null);
@@ -43,21 +49,27 @@ export default function AccountKeys() {
   const [freshKey, setFreshKey] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
   const [error, setError] = useState('');
+  const [needsSignIn, setNeedsSignIn] = useState(false);
+  const [revoking, setRevoking] = useState<string | null>(null);
+  const [refreshing, setRefreshing] = useState(false);
 
   const refresh = useCallback(async () => {
+    setRefreshing(true);
     try {
       const res = await fetch('/api/account');
       if (res.status === 404) {
-        // No grid account on this session (pre-v2 login) — legacy flow.
+        // A readable website session does not guarantee a Core account token.
         setLegacy(true);
         return;
       }
       if (!res.ok) throw new Error('Account fetch failed');
       setAccount(await res.json());
-    } catch (e: any) {
-      setError(e.message ?? 'Could not load account');
+      setLegacy(false);
+    } catch {
+      setError('Could not refresh the key list. Try again.');
     } finally {
       setLoading(false);
+      setRefreshing(false);
     }
   }, []);
 
@@ -65,23 +77,49 @@ export default function AccountKeys() {
     refresh();
   }, [refresh]);
 
+  function mutationError(status: number, action: 'create' | 'revoke') {
+    if (
+      status === 401 ||
+      status === 403 ||
+      (status === 404 && action === 'create')
+    ) {
+      setNeedsSignIn(true);
+      return 'Sign in again with Google or a linked wallet to manage API keys.';
+    }
+    if (status === 429)
+      return 'Too many requests. Wait a moment and try again.';
+    if (status >= 500)
+      return 'Grid is temporarily unavailable. Refresh the key list before retrying.';
+    return `Could not ${action} this key. Refresh the key list and try again.`;
+  }
+
   async function createKey(e: React.FormEvent) {
     e.preventDefault();
     setCreating(true);
     setError('');
+    setNeedsSignIn(false);
     try {
       const res = await fetch('/api/account/keys', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ label: label || 'api' })
       });
-      if (!res.ok) throw new Error('Key creation failed');
+      if (!res.ok) {
+        setError(mutationError(res.status, 'create'));
+        return;
+      }
       const data = await res.json();
+      if (typeof data.api_key !== 'string' || !data.api_key) {
+        throw new Error('Missing new key');
+      }
       setFreshKey(data.api_key);
+      setCopied(false);
       setLabel('');
       await refresh();
-    } catch (e: any) {
-      setError(e.message ?? 'Key creation failed');
+    } catch {
+      setError(
+        'Could not confirm key creation. Refresh the key list before trying again.'
+      );
     } finally {
       setCreating(false);
     }
@@ -92,15 +130,34 @@ export default function AccountKeys() {
       !confirm('Revoke this key? Anything using it stops working immediately.')
     )
       return;
-    await fetch(`/api/account/keys/${id}`, { method: 'DELETE' });
-    await refresh();
+    setRevoking(id);
+    setError('');
+    setNeedsSignIn(false);
+    try {
+      const res = await fetch(`/api/account/keys/${id}`, { method: 'DELETE' });
+      if (!res.ok) {
+        setError(mutationError(res.status, 'revoke'));
+        return;
+      }
+      await refresh();
+    } catch {
+      setError(
+        'Could not confirm revocation. Refresh the key list before trying again.'
+      );
+    } finally {
+      setRevoking(null);
+    }
   }
 
   async function copyKey() {
     if (!freshKey) return;
-    await navigator.clipboard.writeText(freshKey);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
+    try {
+      await navigator.clipboard.writeText(freshKey);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      setError('Clipboard unavailable. Select and copy the displayed key.');
+    }
   }
 
   if (loading) return <p className='text-muted-foreground'>Loading account…</p>;
@@ -145,7 +202,7 @@ export default function AccountKeys() {
           {account?.wallet && (
             <p className='text-sm'>
               <span className='text-muted-foreground'>Linked wallet: </span>
-              <code className='text-green-500'>{account.wallet}</code>
+              <code className='break-all text-green-500'>{account.wallet}</code>
             </p>
           )}
 
@@ -167,18 +224,49 @@ export default function AccountKeys() {
             </div>
           )}
 
-          <form onSubmit={createKey} className='flex gap-2'>
+          <form onSubmit={createKey} className='flex flex-wrap gap-2'>
             <Input
               value={label}
               onChange={(e) => setLabel(e.target.value)}
               placeholder='Key label (e.g. my-agent, prod, laptop)'
               className='max-w-xs'
             />
-            <Button type='submit' disabled={creating}>
+            <Button type='submit' disabled={creating || revoking !== null}>
               {creating ? 'Creating…' : 'Create key'}
             </Button>
+            <Button
+              type='button'
+              variant='outline'
+              size='icon'
+              title='Refresh key list'
+              aria-label='Refresh key list'
+              disabled={refreshing || creating || revoking !== null}
+              onClick={() => void refresh()}
+            >
+              <RefreshCw className='h-4 w-4' />
+            </Button>
           </form>
-          {error && <p className='text-sm text-red-500'>{error}</p>}
+          {error && (
+            <p role='alert' className='text-sm text-red-500'>
+              {error}
+            </p>
+          )}
+          {needsSignIn && (
+            <div className='max-w-sm space-y-3'>
+              <p className='text-sm text-muted-foreground'>
+                Use the Google account or wallet already linked to this account.
+                Signing in does not create or revoke a key.
+              </p>
+              <Suspense
+                fallback={<p className='text-sm'>Loading sign-in options...</p>}
+              >
+                <div className='grid gap-3 [&_button]:mt-0'>
+                  <GoogleSignInButton returnTo='/dashboard/api-key' />
+                  <Web3AuthButton returnTo='/dashboard/api-key' />
+                </div>
+              </Suspense>
+            </div>
+          )}
 
           <Table>
             <TableHeader>
@@ -214,9 +302,10 @@ export default function AccountKeys() {
                       <Button
                         variant='ghost'
                         size='sm'
-                        onClick={() => revoke(k.id)}
+                        disabled={creating || revoking !== null}
+                        onClick={() => void revoke(k.id)}
                       >
-                        Revoke
+                        {revoking === k.id ? 'Revoking...' : 'Revoke'}
                       </Button>
                     )}
                   </TableCell>

--- a/src/features/api-key/lib/pending-key-creation.d.mts
+++ b/src/features/api-key/lib/pending-key-creation.d.mts
@@ -1,0 +1,19 @@
+export interface PendingKeyCreation {
+  accountId: string;
+  label: string;
+}
+
+export const PENDING_KEY_CREATION_KEY: string;
+
+export function rememberPendingKeyCreation(
+  storage: Storage,
+  intent: PendingKeyCreation,
+  now?: number
+): void;
+
+export function takePendingKeyCreation(
+  storage: Storage,
+  now?: number
+): PendingKeyCreation | null;
+
+export function clearPendingKeyCreation(storage: Storage): void;

--- a/src/features/api-key/lib/pending-key-creation.mjs
+++ b/src/features/api-key/lib/pending-key-creation.mjs
@@ -1,0 +1,73 @@
+// SPDX-FileCopyrightText: 2026 AI Power Grid
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+export const PENDING_KEY_CREATION_KEY = 'aipg.console.pending-key-creation.v1';
+
+const VERSION = 1;
+const MAX_AGE_MS = 10 * 60 * 1000;
+const MAX_LABEL_LENGTH = 64;
+const MAX_ACCOUNT_ID_LENGTH = 128;
+
+/**
+ * Remember a rejected key-creation intent immediately before step-up auth.
+ * The intent contains no credential and remains local to the current tab.
+ *
+ * @param {Storage} storage
+ * @param {{ accountId: string, label: string }} intent
+ * @param {number} [now]
+ */
+export function rememberPendingKeyCreation(storage, intent, now = Date.now()) {
+  const accountId = String(intent.accountId ?? '').trim();
+  const label = String(intent.label ?? '').trim();
+  if (
+    !accountId ||
+    accountId.length > MAX_ACCOUNT_ID_LENGTH ||
+    !label ||
+    label.length > MAX_LABEL_LENGTH
+  ) {
+    throw new Error('Invalid pending key creation');
+  }
+  storage.setItem(
+    PENDING_KEY_CREATION_KEY,
+    JSON.stringify({ version: VERSION, accountId, label, createdAt: now })
+  );
+}
+
+/**
+ * Consume before sending so reloads and React remounts cannot duplicate a write.
+ *
+ * @param {Storage} storage
+ * @param {number} [now]
+ * @returns {{ accountId: string, label: string } | null}
+ */
+export function takePendingKeyCreation(storage, now = Date.now()) {
+  const raw = storage.getItem(PENDING_KEY_CREATION_KEY);
+  storage.removeItem(PENDING_KEY_CREATION_KEY);
+  if (!raw) return null;
+  try {
+    const value = JSON.parse(raw);
+    const age = now - Number(value?.createdAt);
+    if (
+      value?.version !== VERSION ||
+      typeof value.accountId !== 'string' ||
+      !value.accountId ||
+      value.accountId.length > MAX_ACCOUNT_ID_LENGTH ||
+      typeof value.label !== 'string' ||
+      !value.label ||
+      value.label.length > MAX_LABEL_LENGTH ||
+      !Number.isFinite(age) ||
+      age < -30_000 ||
+      age > MAX_AGE_MS
+    ) {
+      return null;
+    }
+    return { accountId: value.accountId, label: value.label };
+  } catch {
+    return null;
+  }
+}
+
+/** @param {Storage} storage */
+export function clearPendingKeyCreation(storage) {
+  storage.removeItem(PENDING_KEY_CREATION_KEY);
+}

--- a/src/features/auth/components/google-auth-button.tsx
+++ b/src/features/auth/components/google-auth-button.tsx
@@ -7,9 +7,13 @@ import { Icons } from '@/components/icons';
 import { safeCallbackUrl } from '@/lib/safe-callback-url';
 
 export default function GoogleSignInButton({
-  returnTo
+  returnTo,
+  onBeforeSignIn,
+  onSignInFailed
 }: {
   returnTo?: string;
+  onBeforeSignIn?: () => void;
+  onSignInFailed?: () => void;
 } = {}) {
   const searchParams = useSearchParams();
   const callbackUrl = safeCallbackUrl(
@@ -21,7 +25,14 @@ export default function GoogleSignInButton({
       className='w-full'
       variant='outline'
       type='button'
-      onClick={() => signIn('google', { callbackUrl })}
+      onClick={async () => {
+        onBeforeSignIn?.();
+        try {
+          await signIn('google', { callbackUrl });
+        } catch {
+          onSignInFailed?.();
+        }
+      }}
     >
       <Icons.google className='mr-2 h-4 w-4' />
       Continue with Google

--- a/src/features/auth/components/web3-auth-button.tsx
+++ b/src/features/auth/components/web3-auth-button.tsx
@@ -9,9 +9,13 @@ import { ethers } from 'ethers';
 import { safeCallbackUrl } from '@/lib/safe-callback-url';
 
 export default function Web3AuthButton({
-  returnTo
+  returnTo,
+  onBeforeSignIn,
+  onSignInFailed
 }: {
   returnTo?: string;
+  onBeforeSignIn?: () => void;
+  onSignInFailed?: () => void;
 } = {}) {
   const searchParams = useSearchParams();
   const callbackUrl = safeCallbackUrl(
@@ -98,6 +102,7 @@ export default function Web3AuthButton({
       const signature = await signer.signMessage(message);
 
       // Sign in with NextAuth using credentials
+      onBeforeSignIn?.();
       const result = await signIn('web3', {
         address,
         signature,
@@ -108,6 +113,7 @@ export default function Web3AuthButton({
       });
 
       if (result?.error) {
+        onSignInFailed?.();
         throw new Error(result.error);
       }
 
@@ -116,6 +122,7 @@ export default function Web3AuthButton({
         window.location.href = callbackUrl;
       }
     } catch (err) {
+      onSignInFailed?.();
       console.error('Web3 authentication error:', err);
       setError(
         err instanceof Error


### PR DESCRIPTION
## What and why

Clean-room worker onboarding exposed a stale first-login account proof: the Console hid Core's status behind a generic key error and revocation failures were silent.

- Preserve visible, safe 401/403/429/5xx states for create and revoke.
- Offer the existing Core-verified Google and SIWE step-up paths.
- Retry only a key creation that Core definitely rejected with 401/403.
- Store only account id, label, and timestamp in tab-local storage; consume before sending, expire after ten minutes, and refuse an account mismatch.
- Never auto-retry revocation or an ambiguous transport failure.
- Keep service-refreshed read/inference tokens unable to acquire account.manage.
- Add list refresh, progress states, direct stale-session recovery, and one-time key validation.

## Verification

- Production build and TypeScript pass.
- ESLint and full Prettier check pass.
- Key-management smoke covers anonymous access, expired/stale proof, canceled reauth, one-time successful retry, 401/403/429/5xx, account-bound intent, and service-refresh denial.
- Existing canonical-account auth/credits and validator-pairing smokes pass.
- Production dependency audit reports no known vulnerabilities.
- GitHub checks must pass again for this head before merge.

## Scope and rollout

- No Core permission change, service-key elevation, production deployment, or real key mutation.
- Core remains the authority for identity, canonical account, proof freshness, and account.manage.
- Fresh live Google and wallet canaries remain production rollout gates after source merge.
