### PR TITLE
feat: add secure OAuth consent flow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,5 +36,7 @@ jobs:
         run: pnpm test:auth-smoke
       - name: Test key-management proof boundary
         run: pnpm test:key-management
+      - name: Test OAuth consent boundary
+        run: pnpm test:oauth-consent
       - name: Test validator account pairing boundary
         run: pnpm test:validator-pairing

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,7 +59,8 @@ described as deployable until the build and Worker configuration land together.
   own AGENTS.md.
 - **`src/components/`** — shared/presentational UI (shadcn `ui/`, layout, kbar, providers).
 - **`src/hooks/`, `src/constants/`, `types/`** — shared hooks, static nav/data, global types.
-- **`src/proxy.ts`** — Auth.js route gate for `/dashboard/:path*`.
+- **`src/proxy.ts`** — Auth.js route gate for `/dashboard/:path*` and the
+  capability-bound `/oauth/authorize` consent page.
 - **`public/`** — static assets. **Root config** — `next.config.js`, `next.config.mjs`,
   `tailwind.config.js`, `tsconfig.json`, `env.example.txt`, `vercel.json`.
 
@@ -81,7 +82,9 @@ described as deployable until the build and Worker configuration land together.
   Google and wallet proofs are verified by Core and issue short account-manage
   tokens. GitHub uses a Console-local app identity and receives inference/read
   authority only. Core exchange soft-fails rather than blocking frontend login.
-- **`src/proxy.ts`** gates `/dashboard/:path*` — unauthenticated requests redirect to `/`.
+- **`src/proxy.ts`** gates `/dashboard/:path*` and `/oauth/authorize` —
+  unauthenticated requests redirect to `/`. OAuth callbacks preserve only one
+  strictly shaped opaque request capability.
 
 ## Work Guidance
 
@@ -112,6 +115,9 @@ described as deployable until the build and Worker configuration land together.
 - `pnpm test:validator-pairing` exercises protected pairing routes against a
   local mock Core after the build. Account association remains default off in
   Core until the node client and supervised rollout are complete.
+- `pnpm test:oauth-consent` exercises the protected OAuth consent BFF against a
+  local mock Core: credential isolation, origin/body limits, response schemas,
+  redirect refusal, account-bound refresh, and consent-page privacy headers.
 - `gitleaks detect --source . --no-git --config .gitleaks.toml --redact`, then
   `gitleaks git . --log-opts=HEAD --config .gitleaks.toml --redact` from a full
   clone.

--- a/next.config.js
+++ b/next.config.js
@@ -9,6 +9,15 @@ const nextConfig = {
           { key: 'X-Frame-Options', value: 'DENY' },
           { key: 'Content-Security-Policy', value: "frame-ancestors 'none'" }
         ]
+      },
+      {
+        source: '/oauth/authorize',
+        headers: [
+          { key: 'Referrer-Policy', value: 'no-referrer' },
+          { key: 'X-Frame-Options', value: 'DENY' },
+          { key: 'Content-Security-Policy', value: "frame-ancestors 'none'" },
+          { key: 'Cache-Control', value: 'no-store' }
+        ]
       }
     ];
   },

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "lint:strict": "eslint --max-warnings=0 src",
     "test:auth-smoke": "node scripts/auth-smoke.mjs",
     "test:key-management": "node scripts/key-management-smoke.mjs",
+    "test:oauth-consent": "node scripts/oauth-consent-smoke.mjs",
     "test:validator-pairing": "node scripts/validator-pairing-smoke.mjs",
     "format": "prettier --write .",
     "format:check": "prettier --check .",

--- a/scripts/oauth-consent-smoke.mjs
+++ b/scripts/oauth-consent-smoke.mjs
@@ -1,0 +1,377 @@
+// SPDX-FileCopyrightText: 2026 AI Power Grid
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { once } from 'node:events';
+import http from 'node:http';
+import { encode } from 'next-auth/jwt';
+
+const appOrigin = 'http://127.0.0.1:18904';
+const coreOrigin = 'http://127.0.0.1:18905';
+const authSecret = 'oauth-consent-local-test-secret-only';
+const cookieName = 'authjs.session-token';
+const accountId = '00000000-0000-0000-0000-000000000321';
+const capability = `oauth_req_${'a'.repeat(43)}`;
+const otherCapability = `oauth_req_${'b'.repeat(43)}`;
+const apiPath = `/api/oauth/authorization?request=${capability}`;
+const pagePath = `/oauth/authorize?request=${capability}`;
+let responseMode = 'normal';
+let overrideStatus = 0;
+let expectedToken = 'oauth-test-user-token';
+let exchangeAccount = accountId;
+let followedRedirects = 0;
+const calls = [];
+const mockErrors = [];
+
+async function cookie(overrides = {}) {
+  const value = await encode({
+    token: {
+      sub: 'oauth-test-user',
+      provider_id: 'google_oauth-test-user',
+      name: 'Local OAuth test',
+      email: 'operator@example.test',
+      gridAccountId: accountId,
+      gridAccessToken: 'oauth-test-user-token',
+      gridAccessTokenExpiresAt: Date.now() + 30 * 60 * 1000,
+      ...overrides
+    },
+    secret: authSecret,
+    salt: cookieName,
+    maxAge: 3600
+  });
+  return `${cookieName}=${value}`;
+}
+
+function json(response, status, value) {
+  response.writeHead(status, { 'Content-Type': 'application/json' });
+  response.end(JSON.stringify(value));
+}
+
+function view() {
+  if (responseMode === 'bad-view') {
+    return {
+      client_id: 'client_test',
+      client_name: 'Test agent',
+      redirect_host: 'agent.example',
+      resource: 'https://api.aipowergrid.io',
+      scopes: ['account.manage'],
+      expires_in: 300,
+      api_key: 'DO_NOT_RETURN_CORE_SECRET'
+    };
+  }
+  return {
+    client_id: 'client_test',
+    client_name: 'Test agent',
+    redirect_host: 'agent.example',
+    resource: 'https://api.aipowergrid.io',
+    scopes: ['account.read', 'inference.submit'],
+    expires_in: 300
+  };
+}
+
+const core = http.createServer(async (request, response) => {
+  try {
+    if (request.url === '/unexpected-redirect') {
+      followedRedirects += 1;
+      return json(response, 500, {});
+    }
+    const chunks = [];
+    for await (const chunk of request) chunks.push(chunk);
+    const body = chunks.length
+      ? JSON.parse(Buffer.concat(chunks).toString('utf8'))
+      : undefined;
+    if (request.url === '/v1/auth/service/exchange') {
+      assert.equal(request.headers.apikey, 'oauth-test-service-key');
+      assert.deepEqual(body, { subject: 'google_oauth-test-user' });
+      return json(response, 200, {
+        account_id: exchangeAccount,
+        access_token: 'refreshed-oauth-token',
+        expires_in: 900
+      });
+    }
+    if (!request.url?.startsWith('/v1/oauth/authorization/')) {
+      return json(response, 404, {});
+    }
+    calls.push({ path: request.url, method: request.method, body });
+    assert.equal(request.headers.apikey, 'oauth-test-service-key');
+    assert.equal(request.headers['x-grid-user-token'], expectedToken);
+    assert.equal(request.headers.authorization, undefined);
+    if (overrideStatus) {
+      return json(response, overrideStatus, {
+        detail: 'DO_NOT_RETURN_CORE_ERROR'
+      });
+    }
+    if (responseMode === 'redirect') {
+      response.writeHead(302, {
+        Location: `${coreOrigin}/unexpected-redirect`
+      });
+      return response.end();
+    }
+    if (responseMode === 'oversized') {
+      return json(response, 200, { padding: 'x'.repeat(40_000) });
+    }
+    if (responseMode === 'malformed')
+      return response.end('<html>not json</html>');
+    if (request.url.endsWith('/inspect')) {
+      assert.equal(request.method, 'POST');
+      assert.deepEqual(body, { request: capability });
+      return json(response, 200, view());
+    }
+    assert.equal(request.url, '/v1/oauth/authorization/decision');
+    assert.equal(request.method, 'POST');
+    assert.deepEqual(body, {
+      request: capability,
+      approve: responseMode !== 'deny'
+    });
+    const redirectTo =
+      responseMode === 'bad-redirect'
+        ? 'javascript:alert(1)'
+        : responseMode === 'credential-redirect'
+          ? 'https://user:pass@agent.example/callback'
+          : responseMode === 'fragment-redirect'
+            ? 'https://agent.example/callback#token'
+            : responseMode === 'loopback'
+              ? 'http://127.0.0.1:39211/callback?code=test'
+              : `https://agent.example/callback?${responseMode === 'deny' ? 'error=access_denied' : 'code=test'}`;
+    return json(response, 200, { redirect_to: redirectTo });
+  } catch (error) {
+    mockErrors.push(error);
+    json(response, 500, { error: 'mock assertion failed' });
+  }
+});
+
+await new Promise((resolve, reject) => {
+  core.once('error', reject);
+  core.listen(18905, '127.0.0.1', resolve);
+});
+
+const app = spawn(
+  process.execPath,
+  [
+    'node_modules/next/dist/bin/next',
+    'start',
+    '--hostname',
+    '127.0.0.1',
+    '--port',
+    '18904'
+  ],
+  {
+    env: {
+      ...process.env,
+      AUTH_SECRET: authSecret,
+      NEXTAUTH_SECRET: authSecret,
+      AUTH_TRUST_HOST: 'true',
+      NEXTAUTH_URL: appOrigin,
+      GRID_API_BASE: coreOrigin,
+      GRID_SERVICE_API_KEY: 'oauth-test-service-key'
+    },
+    stdio: ['ignore', 'pipe', 'pipe']
+  }
+);
+let appOutput = '';
+app.stdout.on('data', (chunk) => {
+  appOutput = (appOutput + chunk).slice(-16_000);
+});
+app.stderr.on('data', (chunk) => {
+  appOutput = (appOutput + chunk).slice(-16_000);
+});
+let currentCookie = await cookie();
+
+function request(route, init = {}) {
+  return fetch(`${appOrigin}${route}`, {
+    ...init,
+    headers: { cookie: currentCookie, ...init.headers },
+    signal: AbortSignal.timeout(15_000),
+    redirect: 'manual'
+  });
+}
+
+function post(body = {}, headers = {}) {
+  return request('/api/oauth/authorization', {
+    method: 'POST',
+    headers: {
+      Origin: appOrigin,
+      'Sec-Fetch-Site': 'same-origin',
+      'Content-Type': 'application/json',
+      ...headers
+    },
+    body: typeof body === 'string' ? body : JSON.stringify(body)
+  });
+}
+
+async function status(response, expected) {
+  assert.equal(response.status, expected);
+  assert.equal(response.headers.get('cache-control'), 'no-store');
+  assert.equal(response.headers.get('referrer-policy'), 'no-referrer');
+  const text = await response.text();
+  assert.ok(
+    !/DO_NOT_RETURN|oauth-test-user-token|oauth-test-service-key/.test(text)
+  );
+  return JSON.parse(text);
+}
+
+try {
+  let ready = false;
+  for (let attempt = 0; attempt < 100; attempt++) {
+    try {
+      if ((await fetch(`${appOrigin}${apiPath}`)).status === 401) {
+        ready = true;
+        break;
+      }
+    } catch {
+      // Bounded startup retry against the local production server.
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  assert.ok(ready, `Console failed to start: ${appOutput}`);
+
+  await status(
+    await request(apiPath, {
+      headers: {
+        cookie: '',
+        apikey: 'forged',
+        authorization: 'Bearer forged'
+      }
+    }),
+    401
+  );
+  await status(
+    await post(
+      { request: capability, approve: true },
+      { cookie: '', apikey: 'forged' }
+    ),
+    401
+  );
+  assert.equal(calls.length, 0);
+
+  for (const origin of ['', 'null', 'https://evil.example']) {
+    await status(
+      await post(
+        { request: capability, approve: true },
+        { Origin: origin, 'X-Forwarded-Host': 'evil.example' }
+      ),
+      403
+    );
+  }
+  await status(
+    await post(
+      { request: capability, approve: true },
+      { 'Sec-Fetch-Site': 'cross-site' }
+    ),
+    403
+  );
+  await status(
+    await post(
+      { request: capability, approve: true },
+      { 'Content-Type': 'text/plain' }
+    ),
+    415
+  );
+  for (const body of [
+    '{',
+    JSON.stringify({ request: capability }),
+    JSON.stringify({ request: capability, approve: true, extra: true }),
+    JSON.stringify({ request: otherCapability, approve: 'yes' }),
+    JSON.stringify({ request: capability, approve: true, pad: 'x'.repeat(600) })
+  ]) {
+    await status(await post(body), 400);
+  }
+  await status(await request('/api/oauth/authorization?request=invalid'), 400);
+  assert.equal(calls.length, 0, 'rejected requests must never reach Core');
+
+  const inspected = await status(await request(apiPath), 200);
+  assert.equal(inspected.client_name, 'Test agent');
+  assert.deepEqual(inspected.scopes, ['account.read', 'inference.submit']);
+  assert.equal(calls.at(-1).path, '/v1/oauth/authorization/inspect');
+
+  const approved = await status(
+    await post({ request: capability, approve: true }),
+    200
+  );
+  assert.equal(
+    approved.redirect_to,
+    'https://agent.example/callback?code=test'
+  );
+  responseMode = 'deny';
+  const denied = await status(
+    await post({ request: capability, approve: false }),
+    200
+  );
+  assert.equal(
+    denied.redirect_to,
+    'https://agent.example/callback?error=access_denied'
+  );
+  responseMode = 'loopback';
+  await status(await post({ request: capability, approve: true }), 200);
+
+  for (const code of [400, 401, 403, 404, 409, 410, 413, 415, 429, 503]) {
+    overrideStatus = code;
+    await status(await request(apiPath), code);
+    await status(await post({ request: capability, approve: true }), code);
+  }
+  overrideStatus = 500;
+  await status(await request(apiPath), 502);
+  overrideStatus = 0;
+
+  for (const mode of ['bad-view', 'redirect', 'oversized', 'malformed']) {
+    responseMode = mode;
+    await status(await request(apiPath), 502);
+  }
+  for (const mode of [
+    'bad-redirect',
+    'credential-redirect',
+    'fragment-redirect'
+  ]) {
+    responseMode = mode;
+    await status(await post({ request: capability, approve: true }), 502);
+  }
+  responseMode = 'normal';
+
+  currentCookie = await cookie({ gridAccessTokenExpiresAt: Date.now() - 1 });
+  expectedToken = 'refreshed-oauth-token';
+  await status(await request(apiPath), 200);
+  exchangeAccount = '00000000-0000-0000-0000-000000000999';
+  const beforeMismatch = calls.length;
+  await status(await request(apiPath), 401);
+  assert.equal(calls.length, beforeMismatch, 'account mismatch fails closed');
+  currentCookie = await cookie();
+  expectedToken = 'oauth-test-user-token';
+
+  const page = await request(pagePath);
+  assert.equal(page.status, 200);
+  assert.equal(page.headers.get('cache-control'), 'no-store');
+  assert.equal(page.headers.get('referrer-policy'), 'no-referrer');
+  assert.equal(page.headers.get('x-frame-options'), 'DENY');
+  assert.equal(
+    page.headers.get('content-security-policy'),
+    "frame-ancestors 'none'"
+  );
+  const anonymousPage = await request(pagePath, { headers: { cookie: '' } });
+  assert.ok([302, 307].includes(anonymousPage.status));
+  assert.ok(
+    anonymousPage.headers
+      .get('location')
+      ?.includes(encodeURIComponent(pagePath))
+  );
+
+  assert.equal(mockErrors.length, 0, String(mockErrors[0] ?? ''));
+  assert.equal(
+    followedRedirects,
+    0,
+    'credentials must never follow a Core redirect'
+  );
+  console.log(
+    'OAuth consent auth, origin, body, schema, redirect, refresh and privacy gates passed'
+  );
+} finally {
+  if (app.exitCode === null && app.signalCode === null) {
+    const exited = once(app, 'exit');
+    app.kill('SIGTERM');
+    const killTimer = setTimeout(() => app.kill('SIGKILL'), 5000);
+    await exited;
+    clearTimeout(killTimer);
+  }
+  core.closeAllConnections();
+  await new Promise((resolve) => core.close(resolve));
+}

--- a/src/app/(auth)/(signin)/page.tsx
+++ b/src/app/(auth)/(signin)/page.tsx
@@ -3,7 +3,8 @@ import SignInViewPage from '@/features/auth/components/sigin-view';
 
 export const metadata: Metadata = {
   title: 'Authentication | Sign In',
-  description: 'Sign In page for authentication.'
+  description: 'Sign In page for authentication.',
+  referrer: 'no-referrer'
 };
 
 export default async function Page() {

--- a/src/app/AGENTS.md
+++ b/src/app/AGENTS.md
@@ -13,6 +13,9 @@ public network/payout transparency, and the hosted API reference.
 - `dashboard/connect-validator/[pairingId]/` - protected, short-lived validator
   account-visibility approval. No-referrer metadata/HTTP header and frame denial
   protect the request URL and consent screen. Node confirmation remains local.
+- `oauth/authorize/` - protected, no-referrer OAuth consent page for an opaque,
+  short-lived Core request capability. Login preserves only that exact
+  capability; it never approves the client implicitly.
 - `dashboard/` - protected account pages: overview, API keys, credits/funding,
   usage, rewards, settings, validators, and workers.
 - `payouts/` - public worker payout transparency and live redacted jobs.
@@ -26,7 +29,8 @@ public network/payout transparency, and the hosted API reference.
 
 ## Local Contracts
 
-- `/dashboard/:path*` requires Auth.js through `src/proxy.ts`.
+- `/dashboard/:path*` and `/oauth/authorize` require Auth.js through
+  `src/proxy.ts`.
 - Public pages must not depend on a session or expose account IDs/private job
   data. Public payout data contains only already-public wallets/transactions;
   network status contains only Core-supplied redacted aggregates.
@@ -45,8 +49,8 @@ public network/payout transparency, and the hosted API reference.
 
 - `pnpm lint`
 - `pnpm build`
-- Manually verify unauthenticated dashboard redirect and public `/payouts` and
-  `/network`.
+- Manually verify unauthenticated dashboard/OAuth redirects and public
+  `/payouts` and `/network`.
 
 ## Child DOX Index
 

--- a/src/app/api/AGENTS.md
+++ b/src/app/api/AGENTS.md
@@ -29,6 +29,10 @@ browser JavaScript.
   `validator-pairings/AGENTS.md`, including shared transport rules.
 - `account/validators/` and `[validatorId]/unlink/` - private associated-node
   listing and exact-pairing removal; use that same validator-pairing transport.
+- `oauth/authorization/` - protected consent inspection and approve/deny BFF.
+  It sends the scoped Console service key plus the user's Core token only from
+  the server, requires same-origin strict JSON for decisions, and accepts only
+  bounded/schema-valid Core responses.
 - `account/jobs/` — operator trust view (my workers' jobs + den + proof) via
   `/v1/account/jobs`.
 - `account/payout-preference/` — set payout asset / AIPG slice via the
@@ -60,6 +64,9 @@ browser JavaScript.
 - Do not add direct-database routes. Grid core owns persistence and authorization.
 - Worker-enrollment proxy calls must use the shared bounded timeout and return a
   no-store `502` when Core is unavailable. Never leave a pairing request hanging.
+- OAuth authorization routes never follow Core redirects. They return only
+  redacted error text and schema-valid consent metadata or an HTTPS/native-
+  loopback redirect. All responses are no-store and no-referrer.
 
 ## Work Guidance
 
@@ -68,9 +75,12 @@ browser JavaScript.
 
 ## Verification
 
-- `pnpm test:auth-smoke` and `pnpm test:validator-pairing` after `pnpm build`.
+- `pnpm test:auth-smoke`, `pnpm test:oauth-consent`, and
+  `pnpm test:validator-pairing` after `pnpm build`.
 
 ## Child DOX Index
 
 - [validator-pairings/AGENTS.md](validator-pairings/AGENTS.md) - bounded private
   account-pairing proxies and cross-origin protection.
+- [oauth/AGENTS.md](oauth/AGENTS.md) - bounded OAuth consent proxy and response
+  contracts.

--- a/src/app/api/oauth/AGENTS.md
+++ b/src/app/api/oauth/AGENTS.md
@@ -1,0 +1,34 @@
+# oauth - private remote-agent consent proxy
+
+## Purpose
+
+Server-only Console bridge for inspecting and deciding Core-issued OAuth
+authorization requests without exposing service or user credentials.
+
+## Ownership
+
+- `authorization/route.ts` - GET inspection and POST approve/deny.
+- `authorization/_shared.ts` - session resolution, same-origin/body guards,
+  bounded Core transport, redacted errors, and private response headers.
+
+## Local Contracts
+
+- `request` is an opaque `oauth_req_` capability with the exact configured
+  shape. Do not decode it, persist it, log it, or accept it in another field.
+- POST requires the Console's exact origin, same-origin fetch metadata when
+  present, strict JSON, a 512-byte maximum, and the exact decision schema.
+- Core receives the scoped Console service key and the user's short-lived Core
+  token server-side. Neither may enter a browser response or log.
+- Fetches are bounded, no-store, and `redirect: error`. Successful responses
+  must pass the display/redirect schema; failures expose only stable local text.
+- Final redirects are HTTPS or native loopback HTTP with no credentials or
+  fragment. Core remains authoritative for request expiry, replay, client,
+  scopes, account proof, and decision state.
+
+## Verification
+
+Run `pnpm build` followed by `pnpm test:oauth-consent`.
+
+## Child DOX Index
+
+- None - leaf.

--- a/src/app/api/oauth/authorization/_shared.ts
+++ b/src/app/api/oauth/authorization/_shared.ts
@@ -1,0 +1,111 @@
+// SPDX-FileCopyrightText: 2026 AI Power Grid
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { getSessionToken, resolveGridKey } from '@/lib/grid-account';
+import { GRID_API_BASE } from '@/lib/grid-api';
+import { oauthErrorMessage } from '@/lib/oauth-authorization';
+
+export const privateHeaders = {
+  'Cache-Control': 'no-store',
+  Pragma: 'no-cache',
+  'Referrer-Policy': 'no-referrer',
+  'X-Content-Type-Options': 'nosniff'
+};
+
+export function oauthError(status: number) {
+  return NextResponse.json(
+    { error: oauthErrorMessage(status) },
+    { status, headers: privateHeaders }
+  );
+}
+
+async function boundedJson(
+  stream: ReadableStream<Uint8Array> | null,
+  limit: number
+): Promise<unknown> {
+  if (!stream) throw new Error('Missing JSON body');
+  const reader = stream.getReader();
+  const chunks: Uint8Array[] = [];
+  let size = 0;
+  try {
+    for (;;) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      size += value.byteLength;
+      if (size > limit) throw new Error('JSON body too large');
+      chunks.push(value);
+    }
+    return JSON.parse(Buffer.concat(chunks).toString('utf8'));
+  } finally {
+    await reader.cancel();
+  }
+}
+
+export async function oauthForm<T>(req: NextRequest, schema: z.ZodType<T>) {
+  const site = req.headers.get('sec-fetch-site');
+  const host = req.headers.get('host');
+  if (!host) return { error: oauthError(403) } as const;
+  const origin = `${req.nextUrl.protocol}//${host}`;
+  if (
+    req.headers.get('origin') !== origin ||
+    (site && site !== 'same-origin')
+  ) {
+    return { error: oauthError(403) } as const;
+  }
+  if (
+    req.headers.get('content-type')?.split(';')[0].trim() !== 'application/json'
+  ) {
+    return { error: oauthError(415) } as const;
+  }
+  try {
+    const parsed = schema.safeParse(await boundedJson(req.body, 512));
+    if (!parsed.success) return { error: oauthError(400) } as const;
+    return { data: parsed.data } as const;
+  } catch {
+    return { error: oauthError(400) } as const;
+  }
+}
+
+export async function callOAuth<T>(
+  req: NextRequest,
+  path: string,
+  schema: z.ZodType<T>,
+  body: unknown
+) {
+  try {
+    const serviceKey = process.env.GRID_SERVICE_API_KEY;
+    if (!serviceKey) return oauthError(503);
+    const signal = AbortSignal.timeout(10_000);
+    const userToken = await resolveGridKey(await getSessionToken(req), signal);
+    if (signal.aborted) return oauthError(502);
+    if (!userToken) return oauthError(401);
+    const response = await fetch(`${GRID_API_BASE}${path}`, {
+      method: 'POST',
+      headers: {
+        apikey: serviceKey,
+        'X-Grid-User-Token': userToken,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify(body),
+      cache: 'no-store',
+      redirect: 'error',
+      signal
+    });
+    if (!response.ok) {
+      await response.body?.cancel();
+      const status = [
+        400, 401, 403, 404, 409, 410, 413, 415, 429, 503
+      ].includes(response.status)
+        ? response.status
+        : 502;
+      return oauthError(status);
+    }
+    const parsed = schema.safeParse(await boundedJson(response.body, 32_768));
+    if (!parsed.success) return oauthError(502);
+    return NextResponse.json(parsed.data, { headers: privateHeaders });
+  } catch {
+    return oauthError(502);
+  }
+}

--- a/src/app/api/oauth/authorization/route.ts
+++ b/src/app/api/oauth/authorization/route.ts
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: 2026 AI Power Grid
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { NextRequest } from 'next/server';
+import {
+  oauthAuthorizationViewSchema,
+  oauthDecisionSchema,
+  oauthRedirectSchema,
+  oauthRequestSchema
+} from '@/lib/oauth-authorization';
+import { callOAuth, oauthError, oauthForm } from './_shared';
+
+export async function GET(req: NextRequest) {
+  const request = oauthRequestSchema.safeParse(
+    req.nextUrl.searchParams.get('request')
+  );
+  if (!request.success) return oauthError(400);
+  return callOAuth(
+    req,
+    '/v1/oauth/authorization/inspect',
+    oauthAuthorizationViewSchema,
+    { request: request.data }
+  );
+}
+
+export async function POST(req: NextRequest) {
+  const form = await oauthForm(req, oauthDecisionSchema);
+  if ('error' in form) return form.error;
+  return callOAuth(
+    req,
+    '/v1/oauth/authorization/decision',
+    oauthRedirectSchema,
+    form.data
+  );
+}

--- a/src/app/oauth/authorize/page.tsx
+++ b/src/app/oauth/authorize/page.tsx
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: 2026 AI Power Grid
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import type { Metadata } from 'next';
+import { notFound } from 'next/navigation';
+import PageContainer from '@/components/layout/page-container';
+import OAuthConsent from '@/features/oauth/components/oauth-consent';
+import { oauthRequestSchema } from '@/lib/oauth-authorization';
+
+export const metadata: Metadata = {
+  title: 'Authorize Agent',
+  referrer: 'no-referrer',
+  robots: { index: false, follow: false }
+};
+
+export default async function Page({
+  searchParams
+}: {
+  searchParams: Promise<{ request?: string }>;
+}) {
+  const request = oauthRequestSchema.safeParse((await searchParams).request);
+  if (!request.success) notFound();
+  return (
+    <PageContainer>
+      <OAuthConsent requestCapability={request.data} />
+    </PageContainer>
+  );
+}

--- a/src/features/AGENTS.md
+++ b/src/features/AGENTS.md
@@ -8,6 +8,9 @@ in `src/app/dashboard/<area>/` stay thin and render the matching feature here.
 ## Ownership
 
 - `auth/` — sign-in view + provider buttons (Google, GitHub, Web3). Drives `src/lib/auth`.
+- `oauth/` - explicit remote-agent consent UI. Displays only Core-validated
+  client/scopes/destination data, requires a separate approve or deny action,
+  and offers fresh Google/wallet proof when Core rejects stale authority.
 - `overview/` — dashboard home widgets (pie/area/bar graphs, recent models, quick start,
   about-grid) with skeleton variants for the parallel routes under `dashboard/overview/`.
 - `api-key/` — API-key view + account-keys management UI. Create/revoke failures
@@ -65,6 +68,9 @@ in `src/app/dashboard/<area>/` stay thin and render the matching feature here.
   explicit confirmation on the node. Never auto-approve on login or poll,
   request a node private key, or treat account association as ownership,
   recovery, payout delegation, or operator independence.
+- OAuth consent never treats login as approval and never exposes the Console
+  service key, Core user token, wallet key, or a reusable Grid API key. The
+  browser receives only bounded consent metadata and a validated final redirect.
 - Forms use React Hook Form + Zod schemas (e.g. `profile/utils/form-schema.ts`).
 - Funding may use any wallet that Core has verified on the canonical account.
   The funding selector renders only assets Core marks enabled; disabled future

--- a/src/features/oauth/components/oauth-consent.tsx
+++ b/src/features/oauth/components/oauth-consent.tsx
@@ -1,0 +1,211 @@
+// SPDX-FileCopyrightText: 2026 AI Power Grid
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+'use client';
+
+import { Suspense, useEffect, useState } from 'react';
+import { Bot, Check, ExternalLink, KeyRound, RefreshCw, X } from 'lucide-react';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { Button } from '@/components/ui/button';
+import GoogleSignInButton from '@/features/auth/components/google-auth-button';
+import Web3AuthButton from '@/features/auth/components/web3-auth-button';
+import {
+  OAuthAuthorizationView,
+  OAuthRequestError,
+  oauthAuthorizationViewSchema,
+  oauthRedirectSchema,
+  readOAuthResponse
+} from '@/lib/oauth-authorization';
+
+const scopeCopy = {
+  'account.read': {
+    title: 'Read account status',
+    description: 'View your Grid credit balance and available models.'
+  },
+  'inference.submit': {
+    title: 'Run AI jobs',
+    description: 'Submit metered text, image, video, and audio requests.'
+  }
+} as const;
+
+export default function OAuthConsent({
+  requestCapability
+}: {
+  requestCapability: string;
+}) {
+  const [view, setView] = useState<OAuthAuthorizationView | null>(null);
+  const [error, setError] = useState<OAuthRequestError | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [busy, setBusy] = useState<'approve' | 'deny' | null>(null);
+  const [revision, setRevision] = useState(0);
+  const returnTo = `/oauth/authorize?request=${encodeURIComponent(requestCapability)}`;
+
+  useEffect(() => {
+    const controller = new AbortController();
+    async function load() {
+      try {
+        const next = await readOAuthResponse(
+          await fetch(
+            `/api/oauth/authorization?request=${encodeURIComponent(requestCapability)}`,
+            { cache: 'no-store', signal: controller.signal }
+          ),
+          oauthAuthorizationViewSchema
+        );
+        if (controller.signal.aborted) return;
+        setView(next);
+        setError(null);
+      } catch (cause) {
+        if (controller.signal.aborted) return;
+        setView(null);
+        setError(
+          cause instanceof OAuthRequestError
+            ? cause
+            : new OAuthRequestError(502)
+        );
+      } finally {
+        if (!controller.signal.aborted) setLoading(false);
+      }
+    }
+    void load();
+    return () => controller.abort();
+  }, [requestCapability, revision]);
+
+  async function decide(approve: boolean) {
+    if (!view || busy) return;
+    setBusy(approve ? 'approve' : 'deny');
+    setError(null);
+    try {
+      const result = await readOAuthResponse(
+        await fetch('/api/oauth/authorization', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ request: requestCapability, approve }),
+          cache: 'no-store'
+        }),
+        oauthRedirectSchema
+      );
+      window.location.assign(result.redirect_to);
+    } catch (cause) {
+      setError(
+        cause instanceof OAuthRequestError ? cause : new OAuthRequestError(502)
+      );
+      setBusy(null);
+    }
+  }
+
+  return (
+    <section className='mx-auto w-full min-w-0 max-w-2xl space-y-6 py-6'>
+      <header className='space-y-3'>
+        <div className='flex items-center gap-3'>
+          <Bot className='h-6 w-6 text-primary' aria-hidden='true' />
+          <h1 className='text-2xl font-semibold'>Authorize agent</h1>
+        </div>
+        <p className='text-sm text-muted-foreground'>
+          Review the access request before connecting this agent to your AI
+          Power Grid account.
+        </p>
+      </header>
+
+      {loading && (
+        <p role='status' className='text-sm'>
+          Checking authorization request...
+        </p>
+      )}
+
+      {error && (
+        <div className='space-y-4'>
+          <Alert variant='destructive'>
+            <AlertTitle>Authorization not completed</AlertTitle>
+            <AlertDescription>{error.message}</AlertDescription>
+          </Alert>
+          {[401, 403].includes(error.status) && (
+            <div className='max-w-sm space-y-3'>
+              <p className='text-sm text-muted-foreground'>
+                Confirm with the Google account or wallet linked to this Grid
+                account. Signing in does not approve the agent.
+              </p>
+              <Suspense
+                fallback={<p className='text-sm'>Loading sign-in options...</p>}
+              >
+                <div className='grid gap-3 [&_button]:mt-0'>
+                  <GoogleSignInButton returnTo={returnTo} />
+                  <Web3AuthButton returnTo={returnTo} />
+                </div>
+              </Suspense>
+            </div>
+          )}
+          <Button
+            variant='outline'
+            onClick={() => {
+              setLoading(true);
+              setRevision((value) => value + 1);
+            }}
+          >
+            <RefreshCw className='mr-2 h-4 w-4' />
+            Retry
+          </Button>
+        </div>
+      )}
+
+      {view && (
+        <>
+          <div className='border-y py-5'>
+            <p className='text-sm text-muted-foreground'>Application</p>
+            <p className='mt-1 break-words text-lg font-semibold'>
+              {view.client_name}
+            </p>
+            <p className='mt-3 flex min-w-0 items-center gap-2 text-sm text-muted-foreground'>
+              <ExternalLink className='h-4 w-4 shrink-0' aria-hidden='true' />
+              <span className='min-w-0 break-all'>
+                Returns to {view.redirect_host}
+              </span>
+            </p>
+          </div>
+
+          <div className='space-y-4'>
+            <div className='flex items-center gap-2'>
+              <KeyRound className='h-5 w-5 text-primary' aria-hidden='true' />
+              <h2 className='text-lg font-semibold'>Requested access</h2>
+            </div>
+            <ul className='divide-y border-y'>
+              {view.scopes.map((scope) => (
+                <li key={scope} className='flex gap-3 py-4'>
+                  <Check
+                    className='mt-0.5 h-4 w-4 shrink-0 text-emerald-600'
+                    aria-hidden='true'
+                  />
+                  <div>
+                    <p className='font-medium'>{scopeCopy[scope].title}</p>
+                    <p className='mt-1 text-sm text-muted-foreground'>
+                      {scopeCopy[scope].description}
+                    </p>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          </div>
+
+          <p className='text-sm text-muted-foreground'>
+            Access expires after 15 minutes. The agent receives no password,
+            wallet key, API key, or permission to manage your account.
+          </p>
+
+          <div className='flex flex-wrap gap-3'>
+            <Button onClick={() => void decide(true)} disabled={busy !== null}>
+              <Check className='mr-2 h-4 w-4' />
+              {busy === 'approve' ? 'Authorizing...' : 'Authorize agent'}
+            </Button>
+            <Button
+              variant='outline'
+              onClick={() => void decide(false)}
+              disabled={busy !== null}
+            >
+              <X className='mr-2 h-4 w-4' />
+              {busy === 'deny' ? 'Denying...' : 'Deny'}
+            </Button>
+          </div>
+        </>
+      )}
+    </section>
+  );
+}

--- a/src/lib/AGENTS.md
+++ b/src/lib/AGENTS.md
@@ -18,6 +18,8 @@ provisioning helpers, search parameters, and small shared utilities.
 - `grid-account.ts` — server-side Grid account/session provisioning helpers.
 - `safe-callback-url.ts` — same-origin post-auth navigation guard. Use it for
   any browser-controlled Auth.js callback; Web3 sign-in redirects manually.
+- `oauth-authorization.ts` - strict public display, decision, request-capability,
+  redirect, and error schemas for the remote-agent consent flow.
 - `validator-pairing.ts` - shared Zod display schemas and safe error messages.
   Contains no credentials or signing logic; strips node-only payloads at the
   BFF. Core remains authoritative for proof, ownership and state transitions.
@@ -39,8 +41,9 @@ provisioning helpers, search parameters, and small shared utilities.
 - `grid-api.ts` is the only place that constructs grid URLs/headers — route handlers call
   through it, not raw `fetch`, for cached reads.
 - There is no local DB layer. New account work goes through Grid v1.
-- Browser-controlled auth callbacks are restricted to `/dashboard` routes;
-  never permit an arbitrary same-origin API or action path as a callback.
+- Browser-controlled auth callbacks are restricted to `/dashboard` routes or
+  `/oauth/authorize` with exactly one valid `oauth_req_` capability; never
+  permit an arbitrary same-origin API or action path as a callback.
 
 ## Work Guidance
 

--- a/src/lib/oauth-authorization.ts
+++ b/src/lib/oauth-authorization.ts
@@ -1,0 +1,79 @@
+// SPDX-FileCopyrightText: 2026 AI Power Grid
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { z } from 'zod';
+
+export const oauthRequestSchema = z
+  .string()
+  .regex(/^oauth_req_[A-Za-z0-9_-]{43}$/);
+
+export const oauthScopeSchema = z.enum(['account.read', 'inference.submit']);
+
+export const oauthAuthorizationViewSchema = z.object({
+  client_id: z.string().min(1).max(96),
+  client_name: z.string().min(1).max(120),
+  redirect_host: z.string().min(1).max(253),
+  resource: z.string().url().max(512),
+  scopes: z.array(oauthScopeSchema).min(1).max(2),
+  expires_in: z.number().int().min(0).max(600)
+});
+
+export const oauthDecisionSchema = z
+  .object({
+    request: oauthRequestSchema,
+    approve: z.boolean()
+  })
+  .strict();
+
+export const oauthRedirectSchema = z.object({
+  redirect_to: z
+    .string()
+    .url()
+    .max(4096)
+    .refine((value) => {
+      const url = new URL(value);
+      if (url.username || url.password || url.hash) return false;
+      if (url.protocol === 'https:') return true;
+      return (
+        url.protocol === 'http:' &&
+        ['127.0.0.1', '[::1]', 'localhost'].includes(url.hostname)
+      );
+    })
+});
+
+export type OAuthAuthorizationView = z.infer<
+  typeof oauthAuthorizationViewSchema
+>;
+
+const messages: Record<number, string> = {
+  400: 'This authorization request is malformed.',
+  401: 'Sign in to review this authorization request.',
+  403: 'Confirm your account with Google or a linked wallet to continue.',
+  404: 'This authorization request was not found.',
+  409: 'This authorization request is already closed.',
+  410: 'This authorization request has expired.',
+  413: 'This authorization request is too large.',
+  415: 'This authorization request has an unsupported format.',
+  429: 'Too many authorization attempts. Wait a moment and retry.',
+  503: 'Agent authorization is not available yet.'
+};
+
+export function oauthErrorMessage(status: number): string {
+  return messages[status] ?? 'The Grid could not complete this authorization.';
+}
+
+export class OAuthRequestError extends Error {
+  constructor(public readonly status: number) {
+    super(oauthErrorMessage(status));
+  }
+}
+
+export async function readOAuthResponse<T>(
+  response: Response,
+  schema: z.ZodType<T>
+): Promise<T> {
+  if (!response.ok) throw new OAuthRequestError(response.status);
+  const parsed = schema.safeParse(await response.json());
+  if (!parsed.success) throw new OAuthRequestError(502);
+  return parsed.data;
+}

--- a/src/lib/safe-callback-url.ts
+++ b/src/lib/safe-callback-url.ts
@@ -8,7 +8,18 @@ export function safeCallbackUrl(value: string | null | undefined): string {
     if (parsed.origin !== 'https://console.aipowergrid.io') return '/dashboard';
     if (
       parsed.pathname !== '/dashboard' &&
-      !parsed.pathname.startsWith('/dashboard/')
+      !parsed.pathname.startsWith('/dashboard/') &&
+      !(
+        parsed.pathname === '/oauth/authorize' &&
+        parsed.hash === '' &&
+        parsed.searchParams.getAll('request').length === 1 &&
+        Array.from(parsed.searchParams.keys()).every(
+          (key) => key === 'request'
+        ) &&
+        /^oauth_req_[A-Za-z0-9_-]{43}$/.test(
+          parsed.searchParams.get('request') ?? ''
+        )
+      )
     ) {
       return '/dashboard';
     }

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -17,4 +17,4 @@ export const proxy = auth((req) => {
   }
 });
 
-export const config = { matcher: ['/dashboard/:path*'] };
+export const config = { matcher: ['/dashboard/:path*', '/oauth/authorize'] };


### PR DESCRIPTION
## Summary
- add a protected, capability-bound OAuth consent page for remote agents
- keep Console service and Core user credentials server-side behind a bounded BFF
- require explicit approve/deny, fresh proof when Core requires it, and validated HTTPS/native-loopback redirects
- add no-store/no-referrer/frame protections and hierarchical DOX coverage

## Security properties
- SSO login never implies consent
- only one strictly shaped opaque request capability survives the auth callback
- decision POSTs require exact same-origin strict JSON with a 512-byte body limit
- Core calls are timeout-bounded, never follow redirects, and accept only schema-valid bounded responses
- canonical account mismatch fails closed during token refresh
- browser responses never include the Console service key or Core user token

## Verification
- `pnpm lint:strict`
- `pnpm build`
- `pnpm test:oauth-consent`
- `pnpm test:auth-smoke`
- `pnpm test:key-management`
- `pnpm test:validator-pairing`
- `pnpm format:check`
- `git diff --check`

Core counterpart: AIPowerGrid/grid-core#65. Both features remain dark until Core OAuth is explicitly enabled and the MCP client is ready.
